### PR TITLE
fix makefile rules to create directory first

### DIFF
--- a/dev/Makefile
+++ b/dev/Makefile
@@ -1,7 +1,9 @@
 pdf/%.pdf: %.md
+	@mkdir -p $(@D)
 	pandoc --toc --template template/default.latex -o $@ $<
 
 html/%.html: %.md
+	@mkdir -p $(@D)
 	pandoc --toc -o $@ -s $< --mathjax
 
 all: pdf html


### PR DESCRIPTION
Otherwise running make under dev in a clean checkout fails because pdf
and html directories don't exist yet.