### PR TITLE
[RFC] TEAL improvements: Applications, byte string ops, bnz

### DIFF
--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -102,9 +102,9 @@ For two-argument ops, `A` is the previous element on the stack and `B` is the la
 | `^` | A bitwise-xor B |
 | `~` | bitwise invert value X |
 | `mulw` | A times B out to 128-bit long result as low (top) and high uint64 values on the stack |
-| `cons` | pop two byte strings A and B and join them |
-| `substring` | pop a byte string X. For immediate values in 0..255 N and M: extract a range of bytes from it starting at N up to and including M, push the substring result |
-| `substring3` | pop a byte string A and two integers B and C. Extract a range of bytes from A starting at B up to and including C, push the substring result |
+| `cons` | pop two byte strings A and B and join them, push the result |
+| `substring` | pop a byte string X. For immediate values in 0..255 N and M: extract a range of bytes from it starting at N up to but not including M, push the substring result |
+| `substring3` | pop a byte string A and two integers B and C. Extract a range of bytes from A starting at B up to but not including C, push the substring result |
 
 ### Loading Values
 

--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -102,6 +102,9 @@ For two-argument ops, `A` is the previous element on the stack and `B` is the la
 | `^` | A bitwise-xor B |
 | `~` | bitwise invert value X |
 | `mulw` | A times B out to 128-bit long result as low (top) and high uint64 values on the stack |
+| `cons` | pop two byte strings A and B and join them |
+| `substring` | pop a byte string X. For immediate values in 0..255 N and M: extract a range of bytes from it starting at N up to and including M, push the substring result |
+| `substring3` | pop a byte string A and two integers B and C. Extract a range of bytes from A starting at B up to and including C, push the substring result |
 
 ### Loading Values
 

--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -180,6 +180,7 @@ Global fields are fields that are common to all the transactions in the group. I
 | 2 | MaxTxnLife | uint64 | rounds |
 | 3 | ZeroAddress | []byte | 32 byte address of all zero bytes |
 | 4 | GroupSize | uint64 | Number of transactions in this atomic transaction group. At least 1. |
+| 5 | LogicSigVersion | uint64 |  |
 
 
 

--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -231,6 +231,9 @@ Asset fields include `AssetHolding` and `AssetParam` fields that are used in `as
 | --- | --- |
 | `err` | Error. Panic immediately. This is primarily a fencepost against accidental zero bytes getting compiled into programs. |
 | `bnz` | branch if value X is not zero |
+| `bz` | branch if value X is zero |
+| `b` | branch unconditionally to offset |
+| `return` | use last value on stack as success value; end |
 | `pop` | discard value X from stack |
 | `dup` | duplicate last value on stack |
 

--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -102,7 +102,7 @@ For two-argument ops, `A` is the previous element on the stack and `B` is the la
 | `^` | A bitwise-xor B |
 | `~` | bitwise invert value X |
 | `mulw` | A times B out to 128-bit long result as low (top) and high uint64 values on the stack |
-| `cons` | pop two byte strings A and B and join them, push the result |
+| `concat` | pop two byte strings A and B and join them, push the result |
 | `substring` | pop a byte string X. For immediate values in 0..255 N and M: extract a range of bytes from it starting at N up to but not including M, push the substring result |
 | `substring3` | pop a byte string A and two integers B and C. Extract a range of bytes from A starting at B up to but not including C, push the substring result |
 

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -455,6 +455,8 @@ The `bnz` instruction opcode 0x40 is followed by two immediate data bytes which 
 - Pushes: []byte
 - pop two byte strings A and B and join them
 
+`cons` panics if the result would be greater than 4096 bytes
+
 ## substring
 
 - Opcode: 0x51 {uint8 start position}{uint8 end position}

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -466,6 +466,34 @@ The `bnz` instruction opcode 0x40 is followed by two immediate data bytes which 
 
 At LogicSigVersion 2 it became allowed to branch to the end of the program exactly after the last instruction, removing the need for a last instruction or no-op as a branch target at the end. Branching beyond that may still fail the program.
 
+## bz
+
+- Opcode: 0x41 {0..0x7fff forward branch offset, big endian}
+- Pops: *... stack*, uint64
+- Pushes: _None_
+- branch if value X is zero
+- LogicSigVersion >= 2
+
+See `bnz` for details on how branches work
+
+## b
+
+- Opcode: 0x42 {0..0x7fff forward branch offset, big endian}
+- Pops: _None_
+- Pushes: _None_
+- branch unconditionally to offset
+- LogicSigVersion >= 2
+
+See `bnz` for details on how branches work. `b` always jumps to the offset.
+
+## return
+
+- Opcode: 0x43
+- Pops: *... stack*, uint64
+- Pushes: _None_
+- use last value on stack as success value; end
+- LogicSigVersion >= 2
+
 ## pop
 
 - Opcode: 0x48

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -447,3 +447,24 @@ The `bnz` instruction opcode 0x40 is followed by two immediate data bytes which 
 - Pops: *... stack*, any
 - Pushes: any, any
 - duplicate last value on stack
+
+## cons
+
+- Opcode: 0x50 
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: []byte
+- pop two byte strings A and B and join them
+
+## substring
+
+- Opcode: 0x51 {uint8 start position}{uint8 end position}
+- Pops: *... stack*, []byte
+- Pushes: []byte
+- pop a byte string X. For immediate values in 0..255 N and M: extract a range of bytes from it starting at N up to and including M, push the substring result
+
+## substring3
+
+- Opcode: 0x52 
+- Pops: *... stack*, {[]byte A}, {uint64 B}, {uint64 C}
+- Pushes: []byte
+- pop a byte string A and two integers B and C. Extract a range of bytes from A starting at B up to and including C, push the substring result

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -435,7 +435,7 @@ for notes on transaction fields available, see `txn`. If this transaction is _i_
 
 The `bnz` instruction opcode 0x40 is followed by two immediate data bytes which are a high byte first and low byte second which together form a 16 bit offset which the instruction may branch to. For a bnz instruction at `pc`, if the last element of the stack is not zero then branch to instruction at `pc + 3 + N`, else proceed to next instruction at `pc + 3`. Branch targets must be well aligned instructions. (e.g. Branching to the second byte of a 2 byte op will be rejected.) Branch offsets are currently limited to forward branches only, 0-0x7fff. A future expansion might make this a signed 16 bit integer allowing for backward branches and looping.
 
-At version 2 it became allowed to branch to the end of the program exactly after the last instruction, removing the need for a last instruction or no-op as a branch target at the end. Branching beyond that may still fail the program.
+At LogicSigVersion 2 it became allowed to branch to the end of the program exactly after the last instruction, removing the need for a last instruction or no-op as a branch target at the end. Branching beyond that may still fail the program.
 
 ## pop
 
@@ -451,7 +451,7 @@ At version 2 it became allowed to branch to the end of the program exactly after
 - Pushes: any, any
 - duplicate last value on stack
 
-## cons
+## concat
 
 - Opcode: 0x50 
 - Pops: *... stack*, {[]byte A}, {[]byte B}

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -400,6 +400,7 @@ FirstValidTime causes the program to fail. The field is reserved for future use.
 | 2 | MaxTxnLife | uint64 | rounds |
 | 3 | ZeroAddress | []byte | 32 byte address of all zero bytes |
 | 4 | GroupSize | uint64 | Number of transactions in this atomic transaction group. At least 1. |
+| 5 | LogicSigVersion | uint64 |  |
 
 
 ## gtxn

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -454,7 +454,7 @@ The `bnz` instruction opcode 0x40 is followed by two immediate data bytes which 
 - Opcode: 0x50 
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: []byte
-- pop two byte strings A and B and join them
+- pop two byte strings A and B and join them, push the result
 
 `cons` panics if the result would be greater than 4096 bytes
 
@@ -463,11 +463,11 @@ The `bnz` instruction opcode 0x40 is followed by two immediate data bytes which 
 - Opcode: 0x51 {uint8 start position}{uint8 end position}
 - Pops: *... stack*, []byte
 - Pushes: []byte
-- pop a byte string X. For immediate values in 0..255 N and M: extract a range of bytes from it starting at N up to and including M, push the substring result
+- pop a byte string X. For immediate values in 0..255 N and M: extract a range of bytes from it starting at N up to but not including M, push the substring result
 
 ## substring3
 
 - Opcode: 0x52 
 - Pops: *... stack*, {[]byte A}, {uint64 B}, {uint64 C}
 - Pushes: []byte
-- pop a byte string A and two integers B and C. Extract a range of bytes from A starting at B up to and including C, push the substring result
+- pop a byte string A and two integers B and C. Extract a range of bytes from A starting at B up to but not including C, push the substring result

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -435,6 +435,8 @@ for notes on transaction fields available, see `txn`. If this transaction is _i_
 
 The `bnz` instruction opcode 0x40 is followed by two immediate data bytes which are a high byte first and low byte second which together form a 16 bit offset which the instruction may branch to. For a bnz instruction at `pc`, if the last element of the stack is not zero then branch to instruction at `pc + 3 + N`, else proceed to next instruction at `pc + 3`. Branch targets must be well aligned instructions. (e.g. Branching to the second byte of a 2 byte op will be rejected.) Branch offsets are currently limited to forward branches only, 0-0x7fff. A future expansion might make this a signed 16 bit integer allowing for backward branches and looping.
 
+At version 2 it became allowed to branch to the end of the program exactly after the last instruction, removing the need for a last instruction or no-op as a branch target at the end. Branching beyond that may still fail the program.
+
 ## pop
 
 - Opcode: 0x48 
@@ -455,6 +457,7 @@ The `bnz` instruction opcode 0x40 is followed by two immediate data bytes which 
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: []byte
 - pop two byte strings A and B and join them, push the result
+- LogicSigVersion >= 2
 
 `cons` panics if the result would be greater than 4096 bytes
 
@@ -464,6 +467,7 @@ The `bnz` instruction opcode 0x40 is followed by two immediate data bytes which 
 - Pops: *... stack*, []byte
 - Pushes: []byte
 - pop a byte string X. For immediate values in 0..255 N and M: extract a range of bytes from it starting at N up to but not including M, push the substring result
+- LogicSigVersion >= 2
 
 ## substring3
 
@@ -471,3 +475,4 @@ The `bnz` instruction opcode 0x40 is followed by two immediate data bytes which 
 - Pops: *... stack*, {[]byte A}, {uint64 B}, {uint64 C}
 - Pushes: []byte
 - pop a byte string A and two integers B and C. Extract a range of bytes from A starting at B up to but not including C, push the substring result
+- LogicSigVersion >= 2


### PR DESCRIPTION
A few simple byte string ops will enhance building applications with TEAL. A Note field or an Arg signed and checked by ed25519verify could have bytes parsed apart for multiple values.
Add `global LogicSigVersion` so a script can know what environment it is running in.
Refine `bnz` to allow branching to end without an extra instruction at the end as a no-op branch target.