### PR TITLE
[RFC] TEAL version 2: manage state, bytes, rekeying, etc.

### DIFF
--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -135,7 +135,7 @@ For two-argument ops, `A` is the previous element on the stack and `B` is the la
 | `^` | A bitwise-xor B |
 | `~` | bitwise invert value X |
 | `mulw` | A times B out to 128-bit long result as low (top) and high uint64 values on the stack |
-| `plusw` | A plus B out to 128-bit long result as sum (top) and carry-bit uint64 values on the stack |
+| `addw` | A plus B out to 128-bit long result as sum (top) and carry-bit uint64 values on the stack |
 | `concat` | pop two byte strings A and B and join them, push the result |
 | `substring` | pop a byte string X. For immediate values in 0..255 N and M: extract a range of bytes from it starting at N up to but not including M, push the substring result |
 | `substring3` | pop a byte string A and two integers B and C. Extract a range of bytes from A starting at B up to but not including C, push the substring result |
@@ -243,6 +243,7 @@ Global fields are fields that are common to all the transactions in the group. I
 | 5 | LogicSigVersion | uint64 | Maximum supported TEAL version. LogicSigVersion >= 2. |
 | 6 | Round | uint64 | Current round number. LogicSigVersion >= 2. |
 | 7 | LatestTimestamp | uint64 | Last confirmed block UNIX timestamp. Fails if negative. LogicSigVersion >= 2. |
+| 8 | CurrentApplicationID | uint64 | ID of current application executing. Fails if no such application is executing. LogicSigVersion >= 2. |
 
 
 **Asset Fields**
@@ -287,12 +288,12 @@ Asset fields include `AssetHolding` and `AssetParam` fields that are used in `as
 
 | Op | Description |
 | --- | --- |
-| `balance` | get balance for the requested account specified by Txn.Accounts[A] in microalgos. A is specified as an account index in the Accounts field of the ApplicationCall transaction |
+| `balance` | get balance for the requested account specified by Txn.Accounts[A] in microalgos. A is specified as an account index in the Accounts field of the ApplicationCall transaction, zero index means the sender |
 | `app_opted_in` | check if account specified by Txn.Accounts[A] opted in for the application B => {0 or 1} |
 | `app_local_get` | read from account specified by Txn.Accounts[A] from local state of the current application key B => value |
 | `app_local_get_ex` | read from account specified by Txn.Accounts[A] from local state of the application B key C => {0 or 1 (top), value} |
 | `app_global_get` | read key A from global state of a current application => value |
-| `app_global_get_ex` | read from application A global state key B => {0 or 1 (top), value} |
+| `app_global_get_ex` | read from application Txn.ForeignApps[A] global state key B => {0 or 1 (top), value}. A is specified as an account index in the ForeignApps field of the ApplicationCall transaction, zero index means this app |
 | `app_local_put` | write to account specified by Txn.Accounts[A] to local state of a current application key B with value C |
 | `app_global_put` | write key A and value B to global state of the current application |
 | `app_local_del` | delete from account specified by Txn.Accounts[A] local state key B of the current application |

--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -358,6 +358,8 @@ A program starts with a varuint declaring the version of the compiled code. Any 
 
 For version 1, subsequent bytes after the varuint are program opcode bytes. Future versions could put other metadata following the version identifier.
 
+It is important to prevent newly-introduced transaction fields from breaking assumptions made by older versions of TEAL. If one of the transactions in a group will execute a TEAL program whose version predates a given field, that field must not be set anywhere in the transaction group, or the group will be rejected. For example, executing a TEAL version 1 program on a transaction with RekeyTo set to a nonzero address will cause the program to fail, regardless of the other contents of the program itself.
+
 ## Varuint
 
 A '[proto-buf style variable length unsigned int](https://developers.google.com/protocol-buffers/docs/encoding#varint)' is encoded with 7 data bits per byte and the high bit is 1 if there is a following byte and 0 for the last byte. The lowest order 7 bits are in the first byte, followed by successively higher groups of 7 bits.

--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -299,7 +299,7 @@ Asset fields include `AssetHolding` and `AssetParam` fields that are used in `as
 | `app_local_del` | delete from account specified by Txn.Accounts[A] local state key B of the current application |
 | `app_global_del` | delete key A from a global state of the current application |
 | `asset_holding_get` | read from account specified by Txn.Accounts[A] and asset B holding field X (imm arg) => {0 or 1 (top), value} |
-| `asset_params_get` | read from account specified by Txn.Accounts[A] and asset B params field X (imm arg) => {0 or 1 (top), value} |
+| `asset_params_get` | read from asset Txn.ForeignAssets[A] params field X (imm arg) => {0 or 1 (top), value} |
 
 # Assembler Syntax
 

--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -61,14 +61,17 @@ Constants are pushed onto the stack by `intc`, `intc_[0123]`, `bytec`, and `byte
 ### Named Integer Constants
 
 #### OnComplete
+
+An application transaction must indicate the action to be taken following the execution of its approvalProgram or clearStateProgram. The constants below describe the available actions.
+
 | Value | Constant name | Description |
 | --- | --- | --- |
-| 0 | NoOp | Application transaction will simply call its ApprovalProgram. |
-| 1 | OptIn | Application transaction will allocate some LocalState for the application in the sender's account. |
-| 2 | CloseOut | Application transaction will deallocate some LocalState for the application from the user's account. |
-| 3 | ClearState | Similar to CloseOut, but may never fail. This allows users to reclaim their minimum balance from an application they no longer wish to opt in to. |
-| 4 | UpdateApplication | Application transaction will update the ApprovalProgram and ClearStateProgram for the application. |
-| 5 | DeleteApplication | Application transaction will delete the AppParams for the application from the creator's balance. |
+| 0 | NoOp | Only execute the `ApprovalProgram` associated with this application ID, with no additional effects. |
+| 1 | OptIn | Before executing the `ApprovalProgram`, allocate local state for this application into the sender's account data. |
+| 2 | CloseOut | After executing the `ApprovalProgram`, clear any local state for this application out of the sender's account data. |
+| 3 | ClearState | Don't execute the `ApprovalProgram`, and instead execute the `ClearStateProgram` (which may not reject this transaction). Additionally, clear any local state for this application out of the sender's account data as in `CloseOutOC`. |
+| 4 | UpdateApplication | After executing the `ApprovalProgram`, replace the `ApprovalProgram` and `ClearStateProgram` associated with this application ID with the programs specified in this transaction. |
+| 5 | DeleteApplication | After executing the `ApprovalProgram`, delete the application parameters from the account data of the application's creator. |
 
 #### TypeEnum constants
 | Value | Constant name | Description |
@@ -137,8 +140,8 @@ For two-argument ops, `A` is the previous element on the stack and `B` is the la
 | `mulw` | A times B out to 128-bit long result as low (top) and high uint64 values on the stack |
 | `addw` | A plus B out to 128-bit long result as sum (top) and carry-bit uint64 values on the stack |
 | `concat` | pop two byte strings A and B and join them, push the result |
-| `substring` | pop a byte string X. For immediate values in 0..255 N and M: extract a range of bytes from it starting at N up to but not including M, push the substring result |
-| `substring3` | pop a byte string A and two integers B and C. Extract a range of bytes from A starting at B up to but not including C, push the substring result |
+| `substring` | pop a byte string X. For immediate values in 0..255 M and N: extract a range of bytes from it starting at M up to but not including N, push the substring result. If N <= M, or either is larger than the string length, the program fails |
+| `substring3` | pop a byte string A and two integers B and C. Extract a range of bytes from A starting at B up to but not including C, push the substring result. If C <= B, or either is larger than the string length, the program fails |
 
 ### Loading Values
 
@@ -305,8 +308,9 @@ Asset fields include `AssetHolding` and `AssetParam` fields that are used in `as
 
 The assembler parses line by line. Ops that just use the stack appear on a line by themselves. Ops that take arguments are the op and then whitespace and then any argument or arguments.
 
-The first line may contain a special version pragma `#pragma version X`.
-By default the assembler generates TEAL v1. So that all TEAL v2 programs must start with `#pragma version 2`
+The first line may contain a special version pragma `#pragma version X`, which directs the assembler to generate TEAL bytecode targeting a certain version. For instance, `#pragma version 2` produces bytecode targeting TEAL v2. By default, the assembler targets TEAL v1.
+
+Subsequent lines may contain other pragma declarations (i.e., `#pragma <some-specification>`), pertaining to checks that the assembler should perform before agreeing to emit the program bytes, specific optimizations, etc. Those declarations are optional and cannot alter the semantics as described in this document.
 
 "`//`" prefixes a line comment.
 

--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -140,8 +140,8 @@ For two-argument ops, `A` is the previous element on the stack and `B` is the la
 | `mulw` | A times B out to 128-bit long result as low (top) and high uint64 values on the stack |
 | `addw` | A plus B out to 128-bit long result as sum (top) and carry-bit uint64 values on the stack |
 | `concat` | pop two byte strings A and B and join them, push the result |
-| `substring` | pop a byte string X. For immediate values in 0..255 M and N: extract a range of bytes from it starting at M up to but not including N, push the substring result. If N <= M, or either is larger than the string length, the program fails |
-| `substring3` | pop a byte string A and two integers B and C. Extract a range of bytes from A starting at B up to but not including C, push the substring result. If C <= B, or either is larger than the string length, the program fails |
+| `substring` | pop a byte string X. For immediate values in 0..255 M and N: extract a range of bytes from it starting at M up to but not including N, push the substring result. If N < M, or either is larger than the string length, the program fails |
+| `substring3` | pop a byte string A and two integers B and C. Extract a range of bytes from A starting at B up to but not including C, push the substring result. If C < B, or either is larger than the string length, the program fails |
 
 ### Loading Values
 

--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -37,7 +37,16 @@ A program can either authorize some delegated action on a normal private key sig
 
 The TEAL bytecode plus the length of any Args must add up to less than 1000 bytes (consensus parameter LogicSigMaxSize). Each TEAL op has an associated cost estimate and the program cost estimate must total less than 20000 (consensus parameter LogicSigMaxCost). Most ops have an estimated cost of 1, but a few slow crypto ops are much higher.
 
+## Execution modes
 
+Starting from version 2 TEAL evaluator can run programs in two modes:
+1. Signature verification (stateless)
+2. Application run (stateful)
+
+Differences between modes include:
+1. Max program length (consensus parameters LogicSigMaxSize, MaxApprovalProgramLen and MaxClearStateProgramLen)
+2. Max program cost (consensus parameters LogicSigMaxCost, MaxAppProgramCost)
+3. Opcodes availability. For example, all stateful operations are only available in stateful mode. Refer to [opcodes document](TEAL_opcodes.md) for details.
 
 ## Constants
 
@@ -48,6 +57,30 @@ The assembler will hide most of this, allowing simple use of `int 1234` and `byt
 Constants are loaded into the environment by two opcodes, `intcblock` and `bytecblock`. Both of these use [proto-buf style variable length unsigned int](https://developers.google.com/protocol-buffers/docs/encoding#varint), reproduced [here](#varuint). The `intcblock` opcode is followed by a varuint specifying the length of the array and then that number of varuint. The `bytecblock` opcode is followed by a varuint array length then that number of pairs of (varuint, bytes) length prefixed byte strings. This should efficiently load 32 and 64 byte constants which will be common as addresses, hashes, and signatures.
 
 Constants are pushed onto the stack by `intc`, `intc_[0123]`, `bytec`, and `bytec_[0123]`. The assembler will handle converting `int N` or `byte N` into the appropriate form of the instruction needed.
+
+### Named Integer Constants
+
+#### OnComplete
+| Value | Constant name | Description |
+| --- | --- | --- |
+| 0 | NoOp | Application transaction will simply call its ApprovalProgram. |
+| 1 | OptIn | Application transaction will allocate some LocalState for the application in the sender's account. |
+| 2 | CloseOut | Application transaction will deallocate some LocalState for the application from the user's account. |
+| 3 | ClearState | Similar to CloseOut, but may never fail. This allows users to reclaim their minimum balance from an application they no longer wish to opt in to. |
+| 4 | UpdateApplication | Application transaction will update the ApprovalProgram and ClearStateProgram for the application. |
+| 5 | DeleteApplication | Application transaction will delete the AppParams for the application from the creator's balance. |
+
+#### TypeEnum constants
+| Value | Constant name | Description |
+| --- | --- | --- |
+| 0 | unknown | Unknown type. Invalid transaction |
+| 1 | pay | Payment |
+| 2 | keyreg | KeyRegistration |
+| 3 | acfg | AssetConfig |
+| 4 | axfer | AssetTransfer |
+| 5 | afrz | AssetFreeze |
+| 6 | appl | ApplicationCall |
+
 
 ## Operations
 
@@ -102,6 +135,10 @@ For two-argument ops, `A` is the previous element on the stack and `B` is the la
 | `^` | A bitwise-xor B |
 | `~` | bitwise invert value X |
 | `mulw` | A times B out to 128-bit long result as low (top) and high uint64 values on the stack |
+| `plusw` | A plus B out to 128-bit long result as sum (top) and carry-bit uint64 values on the stack |
+| `concat` | pop two byte strings A and B and join them, push the result |
+| `substring` | pop a byte string X. For immediate values in 0..255 N and M: extract a range of bytes from it starting at N up to but not including M, push the substring result |
+| `substring3` | pop a byte string A and two integers B and C. Extract a range of bytes from A starting at B up to but not including C, push the substring result |
 
 ### Loading Values
 
@@ -130,6 +167,8 @@ Some of these have immediate data in the byte or bytes after the opcode.
 | `arg_3` | push Args[3] to stack |
 | `txn` | push field from current transaction to stack |
 | `gtxn` | push field to the stack from a transaction in the current transaction group |
+| `txna` | push value of an array field from current transaction to stack |
+| `gtxna` | push value of a field to the stack from a transaction in the current transaction group |
 | `global` | push value from globals to stack |
 | `load` | copy a value from scratch space to the stack |
 | `store` | pop a value from the stack and store to scratch space |
@@ -141,7 +180,7 @@ Some of these have immediate data in the byte or bytes after the opcode.
 | 0 | Sender | []byte | 32 byte address |
 | 1 | Fee | uint64 | micro-Algos |
 | 2 | FirstValid | uint64 | round number |
-| 3 | FirstValidTime | uint64 | Causes program to fail; reserved for future use. |
+| 3 | FirstValidTime | uint64 | Causes program to fail; reserved for future use |
 | 4 | LastValid | uint64 | round number |
 | 5 | Note | []byte |  |
 | 6 | Lease | []byte |  |
@@ -160,8 +199,32 @@ Some of these have immediate data in the byte or bytes after the opcode.
 | 19 | AssetSender | []byte | 32 byte address. Causes clawback of all value of asset from AssetSender if Sender is the Clawback address of the asset. |
 | 20 | AssetReceiver | []byte | 32 byte address |
 | 21 | AssetCloseTo | []byte | 32 byte address |
-| 22 | GroupIndex | uint64 | Position of this transaction within an atomic transaction group. A stand-alone transaction is implicitly element 0 in a group of 1. |
+| 22 | GroupIndex | uint64 | Position of this transaction within an atomic transaction group. A stand-alone transaction is implicitly element 0 in a group of 1 |
 | 23 | TxID | []byte | The computed ID for this transaction. 32 bytes. |
+| 24 | ApplicationID | uint64 | ApplicationID from ApplicationCall transaction. LogicSigVersion >= 2. |
+| 25 | OnCompletion | uint64 | ApplicationCall transaction on completion action. LogicSigVersion >= 2. |
+| 26 | ApplicationArgs | []byte | Arguments passed to the application in the ApplicationCall transaction. LogicSigVersion >= 2. |
+| 27 | NumAppArgs | uint64 | Number of ApplicationArgs. LogicSigVersion >= 2. |
+| 28 | Accounts | []byte | Accounts listed in the ApplicationCall transaction. LogicSigVersion >= 2. |
+| 29 | NumAccounts | uint64 | Number of Accounts. LogicSigVersion >= 2. |
+| 30 | ApprovalProgram | []byte | Approval program. LogicSigVersion >= 2. |
+| 31 | ClearStateProgram | []byte | Clear state program. LogicSigVersion >= 2. |
+| 32 | RekeyTo | []byte | 32 byte Sender's new AuthAddr. LogicSigVersion >= 2. |
+| 33 | ConfigAsset | uint64 | Asset ID in asset config transaction. LogicSigVersion >= 2. |
+| 34 | ConfigAssetTotal | uint64 | Total number of units of this asset created. LogicSigVersion >= 2. |
+| 35 | ConfigAssetDecimals | uint64 | Number of digits to display after the decimal place when displaying the asset. LogicSigVersion >= 2. |
+| 36 | ConfigAssetDefaultFrozen | uint64 | Whether the asset's slots are frozen by default or not, 0 or 1. LogicSigVersion >= 2. |
+| 37 | ConfigAssetUnitName | []byte | Unit name of the asset. LogicSigVersion >= 2. |
+| 38 | ConfigAssetName | []byte | The asset name. LogicSigVersion >= 2. |
+| 39 | ConfigAssetURL | []byte | URL. LogicSigVersion >= 2. |
+| 40 | ConfigAssetMetadataHash | []byte | 32 byte commitment to some unspecified asset metadata. LogicSigVersion >= 2. |
+| 41 | ConfigAssetManager | []byte | 32 byte address. LogicSigVersion >= 2. |
+| 42 | ConfigAssetReserve | []byte | 32 byte address. LogicSigVersion >= 2. |
+| 43 | ConfigAssetFreeze | []byte | 32 byte address. LogicSigVersion >= 2. |
+| 44 | ConfigAssetClawback | []byte | 32 byte address. LogicSigVersion >= 2. |
+| 45 | FreezeAsset | uint64 | Asset ID being frozen or un-frozen. LogicSigVersion >= 2. |
+| 46 | FreezeAssetAccount | []byte | 32 byte address of the account whose asset slot is being frozen or un-frozen. LogicSigVersion >= 2. |
+| 47 | FreezeAssetFrozen | uint64 | The new frozen value, 0 or 1. LogicSigVersion >= 2. |
 
 
 Additional details in the [opcodes document](TEAL_opcodes.md#txn) on the `txn` op.
@@ -176,8 +239,35 @@ Global fields are fields that are common to all the transactions in the group. I
 | 1 | MinBalance | uint64 | micro Algos |
 | 2 | MaxTxnLife | uint64 | rounds |
 | 3 | ZeroAddress | []byte | 32 byte address of all zero bytes |
-| 4 | GroupSize | uint64 | Number of transactions in this atomic transaction group. At least 1. |
+| 4 | GroupSize | uint64 | Number of transactions in this atomic transaction group. At least 1 |
+| 5 | LogicSigVersion | uint64 | Maximum supported TEAL version. LogicSigVersion >= 2. |
+| 6 | Round | uint64 | Current round number. LogicSigVersion >= 2. |
+| 7 | LatestTimestamp | uint64 | Last confirmed block UNIX timestamp. Fails if negative. LogicSigVersion >= 2. |
 
+
+**Asset Fields**
+
+Asset fields include `AssetHolding` and `AssetParam` fields that are used in `asset_read_*` opcodes
+
+| Index | Name | Type | Notes |
+| --- | --- | --- | --- |
+| 0 | AssetBalance | uint64 | Amount of the asset unit held by this account |
+| 1 | AssetFrozen | uint64 | Is the asset frozen or not |
+
+
+| Index | Name | Type | Notes |
+| --- | --- | --- | --- |
+| 0 | AssetTotal | uint64 | Total number of units of this asset |
+| 1 | AssetDecimals | uint64 | See AssetParams.Decimals |
+| 2 | AssetDefaultFrozen | uint64 | Frozen by default or not |
+| 3 | AssetUnitName | []byte | Asset unit name |
+| 4 | AssetName | []byte | Asset name |
+| 5 | AssetURL | []byte | URL with additional info about the asset |
+| 6 | AssetMetadataHash | []byte | Arbitrary commitment |
+| 7 | AssetManager | []byte | Manager commitment |
+| 8 | AssetReserve | []byte | Reserve address |
+| 9 | AssetFreeze | []byte | Freeze address |
+| 10 | AssetClawback | []byte | Clawback address |
 
 
 ### Flow Control
@@ -186,12 +276,36 @@ Global fields are fields that are common to all the transactions in the group. I
 | --- | --- |
 | `err` | Error. Panic immediately. This is primarily a fencepost against accidental zero bytes getting compiled into programs. |
 | `bnz` | branch if value X is not zero |
+| `bz` | branch if value X is zero |
+| `b` | branch unconditionally to offset |
+| `return` | use last value on stack as success value; end |
 | `pop` | discard value X from stack |
 | `dup` | duplicate last value on stack |
+| `dup2` | duplicate two last values on stack: A, B -> A, B, A, B |
+
+### State Access
+
+| Op | Description |
+| --- | --- |
+| `balance` | get balance for the requested account specified by Txn.Accounts[A] in microalgos. A is specified as an account index in the Accounts field of the ApplicationCall transaction |
+| `app_opted_in` | check if account specified by Txn.Accounts[A] opted in for the application B => {0 or 1} |
+| `app_local_get` | read from account specified by Txn.Accounts[A] from local state of the current application key B => value |
+| `app_local_get_ex` | read from account specified by Txn.Accounts[A] from local state of the application B key C => {0 or 1 (top), value} |
+| `app_global_get` | read key A from global state of a current application => value |
+| `app_global_get_ex` | read from application A global state key B => {0 or 1 (top), value} |
+| `app_local_put` | write to account specified by Txn.Accounts[A] to local state of a current application key B with value C |
+| `app_global_put` | write key A and value B to global state of the current application |
+| `app_local_del` | delete from account specified by Txn.Accounts[A] local state key B of the current application |
+| `app_global_del` | delete key A from a global state of the current application |
+| `asset_holding_get` | read from account specified by Txn.Accounts[A] and asset B holding field X (imm arg) => {0 or 1 (top), value} |
+| `asset_params_get` | read from account specified by Txn.Accounts[A] and asset B params field X (imm arg) => {0 or 1 (top), value} |
 
 # Assembler Syntax
 
 The assembler parses line by line. Ops that just use the stack appear on a line by themselves. Ops that take arguments are the op and then whitespace and then any argument or arguments.
+
+The first line may contain a special version pragma `#pragma version X`.
+By default the assembler generates TEAL v1. So that all TEAL v2 programs must start with `#pragma version 2`
 
 "`//`" prefixes a line comment.
 
@@ -210,13 +324,15 @@ byte b32 AAAA...
 byte base32(AAAA...)
 byte b32(AAAA...)
 byte 0x0123456789abcdef...
+byte "\x01\x02"
+byte "string literal"
 ```
 
 `int` constants may be `0x` prefixed for hex, `0` prefixed for octal, or decimal numbers.
 
 `intcblock` may be explictly assembled. It will conflict with the assembler gathering `int` pseudo-ops into a `intcblock` program prefix, but may be used if code only has explicit `intc` references. `intcblock` should be followed by space separated int constants all on one line.
 
-`bytecblock` may be explicitly assembled. It will conflict with the assembler if there are any `byte` pseudo-ops but may be used if only explicit `bytec` references are used. `bytecblock` should be followed with byte constants all on one line, either 'encoding value' pairs (`b64 AAA...`) or 0x prefix or function-style values (`base64(...)`).
+`bytecblock` may be explicitly assembled. It will conflict with the assembler if there are any `byte` pseudo-ops but may be used if only explicit `bytec` references are used. `bytecblock` should be followed with byte constants all on one line, either 'encoding value' pairs (`b64 AAA...`) or 0x prefix or function-style values (`base64(...)`) or string literal values.
 
 ## Labels and Branches
 
@@ -246,9 +362,9 @@ A '[proto-buf style variable length unsigned int](https://developers.google.com/
 Current design and implementation limitations to be aware of.
 
 * TEAL cannot create or change a transaction, only approve or reject.
-* TEAL cannot lookup balances of Algos or other assets. (Standard transaction accounting will apply after TEAL has run and authorized a transaction. A TEAL-approved transaction could still be invalid by other accounting rules just as a standard signed transaction could be invalid. e.g. I can't give away money I don't have.)
+* Stateless TEAL cannot lookup balances of Algos or other assets. (Standard transaction accounting will apply after TEAL has run and authorized a transaction. A TEAL-approved transaction could still be invalid by other accounting rules just as a standard signed transaction could be invalid. e.g. I can't give away money I don't have.)
 * TEAL cannot access information in previous blocks. TEAL cannot access most information in other transactions in the current block. (TEAL can access fields of the transaction it is attached to and the transactions in an atomic transaction group.)
 * TEAL cannot know exactly what round the current transaction will commit in (but it is somewhere in FirstValid through LastValid).
 * TEAL cannot know exactly what time its transaction is committed.
-* TEAL cannot loop. Its branch instruction `bnz` "branch if not zero" can only branch forward so as to skip some code.
+* TEAL cannot loop. Its branch instructions `bnz` "branch if not zero", `bz` "branch if zero" and `b` "branch" can only branch forward so as to skip some code.
 * TEAL cannot recurse. There is no subroutine jump operation.

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -501,7 +501,7 @@ for notes on transaction fields available, see `txn`. If this transaction is _i_
 
 The `bnz` instruction opcode 0x40 is followed by two immediate data bytes which are a high byte first and low byte second which together form a 16 bit offset which the instruction may branch to. For a bnz instruction at `pc`, if the last element of the stack is not zero then branch to instruction at `pc + 3 + N`, else proceed to next instruction at `pc + 3`. Branch targets must be well aligned instructions. (e.g. Branching to the second byte of a 2 byte op will be rejected.) Branch offsets are currently limited to forward branches only, 0-0x7fff. A future expansion might make this a signed 16 bit integer allowing for backward branches and looping.
 
-At LogicSigVersion 2 it became allowed to branch to the end of the program exactly after the last instruction, removing the need for a last instruction or no-op as a branch target at the end. Branching beyond that may still fail the program.
+At LogicSigVersion 2 it became allowed to branch to the end of the program exactly after the last instruction, removing the need for a last instruction or no-op as a branch target at the end. Branching beyond that may still fail the program. In other words, for a TEAL program with N bytes, a bnz to byte N (with 0-indexing) is illegal before LogicSigVersion 2 and is legal after it.
 
 ## bz
 
@@ -568,7 +568,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 - Opcode: 0x51 {uint8 start position}{uint8 end position}
 - Pops: *... stack*, []byte
 - Pushes: []byte
-- pop a byte string X. For immediate values in 0..255 N and M: extract a range of bytes from it starting at N up to but not including M, push the substring result
+- pop a byte string X. For immediate values in 0..255 M and N: extract a range of bytes from it starting at M up to but not including N, push the substring result. If N <= M, or either is larger than the string length, the program fails
 - LogicSigVersion >= 2
 
 ## substring3
@@ -576,7 +576,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 - Opcode: 0x52
 - Pops: *... stack*, {[]byte A}, {uint64 B}, {uint64 C}
 - Pushes: []byte
-- pop a byte string A and two integers B and C. Extract a range of bytes from A starting at B up to but not including C, push the substring result
+- pop a byte string A and two integers B and C. Extract a range of bytes from A starting at B up to but not including C, push the substring result. If C <= B, or either is larger than the string length, the program fails
 - LogicSigVersion >= 2
 
 ## balance

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -66,7 +66,7 @@ The 32 byte public key is the last element on the stack, preceded by the 64 byte
 - Pushes: uint64
 - A plus B. Panic on overflow.
 
-Overflow is an error condition which halts execution and fails the transaction. Full precision is available from `plusw`.
+Overflow is an error condition which halts execution and fails the transaction. Full precision is available from `addw`.
 
 ## -
 
@@ -219,7 +219,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 - Pushes: uint64, uint64
 - A times B out to 128-bit long result as low (top) and high uint64 values on the stack
 
-## plusw
+## addw
 
 - Opcode: 0x1e
 - Pops: *... stack*, {uint64 A}, {uint64 B}
@@ -450,6 +450,7 @@ FirstValidTime causes the program to fail. The field is reserved for future use.
 | 5 | LogicSigVersion | uint64 | Maximum supported TEAL version. LogicSigVersion >= 2. |
 | 6 | Round | uint64 | Current round number. LogicSigVersion >= 2. |
 | 7 | LatestTimestamp | uint64 | Last confirmed block UNIX timestamp. Fails if negative. LogicSigVersion >= 2. |
+| 8 | CurrentApplicationID | uint64 | ID of current application executing. Fails if no such application is executing. LogicSigVersion >= 2. |
 
 
 ## gtxn
@@ -583,7 +584,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 - Opcode: 0x60
 - Pops: *... stack*, uint64
 - Pushes: uint64
-- get balance for the requested account specified by Txn.Accounts[A] in microalgos. A is specified as an account index in the Accounts field of the ApplicationCall transaction
+- get balance for the requested account specified by Txn.Accounts[A] in microalgos. A is specified as an account index in the Accounts field of the ApplicationCall transaction, zero index means the sender
 - LogicSigVersion >= 2
 - Mode: Application
 
@@ -636,11 +637,11 @@ params: state key. Return: value. The value is zero if the key does not exist.
 - Opcode: 0x65
 - Pops: *... stack*, {uint64 A}, {[]byte B}
 - Pushes: uint64, any
-- read from application A global state key B => {0 or 1 (top), value}
+- read from application Txn.ForeignApps[A] global state key B => {0 or 1 (top), value}. A is specified as an account index in the ForeignApps field of the ApplicationCall transaction, zero index means this app
 - LogicSigVersion >= 2
 - Mode: Application
 
-params: application id, state key. Return: value.
+params: application index, state key. Return: value. Application index is
 
 ## app_local_put
 

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -568,7 +568,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 - Opcode: 0x51 {uint8 start position}{uint8 end position}
 - Pops: *... stack*, []byte
 - Pushes: []byte
-- pop a byte string X. For immediate values in 0..255 M and N: extract a range of bytes from it starting at M up to but not including N, push the substring result. If N <= M, or either is larger than the string length, the program fails
+- pop a byte string X. For immediate values in 0..255 M and N: extract a range of bytes from it starting at M up to but not including N, push the substring result. If N < M, or either is larger than the string length, the program fails
 - LogicSigVersion >= 2
 
 ## substring3
@@ -576,7 +576,7 @@ See `bnz` for details on how branches work. `b` always jumps to the offset.
 - Opcode: 0x52
 - Pops: *... stack*, {[]byte A}, {uint64 B}, {uint64 C}
 - Pushes: []byte
-- pop a byte string A and two integers B and C. Extract a range of bytes from A starting at B up to but not including C, push the substring result. If C <= B, or either is larger than the string length, the program fails
+- pop a byte string A and two integers B and C. Extract a range of bytes from A starting at B up to but not including C, push the substring result. If C < B, or either is larger than the string length, the program fails
 - LogicSigVersion >= 2
 
 ## balance

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -707,9 +707,9 @@ params: account index, asset id. Return: did_exist flag (1 if exist and 0 otherw
 ## asset_params_get
 
 - Opcode: 0x71 {uint8 asset params field index}
-- Pops: *... stack*, {uint64 A}, {uint64 B}
+- Pops: *... stack*, uint64
 - Pushes: uint64, any
-- read from account specified by Txn.Accounts[A] and asset B params field X (imm arg) => {0 or 1 (top), value}
+- read from asset Txn.ForeignAssets[A] params field X (imm arg) => {0 or 1 (top), value}
 - LogicSigVersion >= 2
 - Mode: Application
 
@@ -730,4 +730,4 @@ params: account index, asset id. Return: did_exist flag (1 if exist and 0 otherw
 | 10 | AssetClawback | []byte | Clawback address |
 
 
-params: account index, asset id. Return: did_exist flag (1 if exist and 0 otherwise), value.
+params: txn.ForeignAssets offset. Return: did_exist flag (1 if exist and 0 otherwise), value.

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -13,69 +13,78 @@ Ops have a 'cost' of 1 unless otherwise specified.
 
 ## err
 
-- Opcode: 0x00 
+- Opcode: 0x00
 - Pops: _None_
 - Pushes: _None_
 - Error. Panic immediately. This is primarily a fencepost against accidental zero bytes getting compiled into programs.
 
 ## sha256
 
-- Opcode: 0x01 
+- Opcode: 0x01
 - Pops: *... stack*, []byte
 - Pushes: []byte
 - SHA256 hash of value X, yields [32]byte
-- **Cost**: 7
+- **Cost**:
+   - 7 (LogicSigVersion = 1)
+   - 35 (LogicSigVersion = 2)
 
 ## keccak256
 
-- Opcode: 0x02 
+- Opcode: 0x02
 - Pops: *... stack*, []byte
 - Pushes: []byte
 - Keccak256 hash of value X, yields [32]byte
-- **Cost**: 26
+- **Cost**:
+   - 26 (LogicSigVersion = 1)
+   - 130 (LogicSigVersion = 2)
 
 ## sha512_256
 
-- Opcode: 0x03 
+- Opcode: 0x03
 - Pops: *... stack*, []byte
 - Pushes: []byte
 - SHA512_256 hash of value X, yields [32]byte
-- **Cost**: 9
+- **Cost**:
+   - 9 (LogicSigVersion = 1)
+   - 45 (LogicSigVersion = 2)
 
 ## ed25519verify
 
-- Opcode: 0x04 
+- Opcode: 0x04
 - Pops: *... stack*, {[]byte A}, {[]byte B}, {[]byte C}
 - Pushes: uint64
 - for (data A, signature B, pubkey C) verify the signature of ("ProgData" || program_hash || data) against the pubkey => {0 or 1}
 - **Cost**: 1900
+- Mode: Signature
 
-The 32 byte public key is the last element on the stack, preceeded by the 64 byte signature at the second-to-last element on the stack, preceeded by the data which was signed at the third-to-last element on the stack.
+The 32 byte public key is the last element on the stack, preceded by the 64 byte signature at the second-to-last element on the stack, preceded by the data which was signed at the third-to-last element on the stack.
 
 ## +
 
-- Opcode: 0x08 
+- Opcode: 0x08
 - Pops: *... stack*, {uint64 A}, {uint64 B}
 - Pushes: uint64
 - A plus B. Panic on overflow.
 
+Overflow is an error condition which halts execution and fails the transaction. Full precision is available from `plusw`.
+
 ## -
 
-- Opcode: 0x09 
+- Opcode: 0x09
 - Pops: *... stack*, {uint64 A}, {uint64 B}
 - Pushes: uint64
 - A minus B. Panic if B > A.
 
 ## /
 
-- Opcode: 0x0a 
+- Opcode: 0x0a
 - Pops: *... stack*, {uint64 A}, {uint64 B}
 - Pushes: uint64
 - A divided by B. Panic if B == 0.
 
 ## *
 
-- Opcode: 0x0b 
+- Opcode: 0x0b
 - Pops: *... stack*, {uint64 A}, {uint64 B}
 - Pushes: uint64
 - A times B. Panic on overflow.
@@ -84,131 +93,139 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 ## <
 
-- Opcode: 0x0c 
+- Opcode: 0x0c
 - Pops: *... stack*, {uint64 A}, {uint64 B}
 - Pushes: uint64
 - A less than B => {0 or 1}
 
 ## >
 
-- Opcode: 0x0d 
+- Opcode: 0x0d
 - Pops: *... stack*, {uint64 A}, {uint64 B}
 - Pushes: uint64
 - A greater than B => {0 or 1}
 
 ## <=
 
-- Opcode: 0x0e 
+- Opcode: 0x0e
 - Pops: *... stack*, {uint64 A}, {uint64 B}
 - Pushes: uint64
 - A less than or equal to B => {0 or 1}
 
 ## >=
 
-- Opcode: 0x0f 
+- Opcode: 0x0f
 - Pops: *... stack*, {uint64 A}, {uint64 B}
 - Pushes: uint64
 - A greater than or equal to B => {0 or 1}
 
 ## &&
 
-- Opcode: 0x10 
+- Opcode: 0x10
 - Pops: *... stack*, {uint64 A}, {uint64 B}
 - Pushes: uint64
 - A is not zero and B is not zero => {0 or 1}
 
 ## ||
 
-- Opcode: 0x11 
+- Opcode: 0x11
 - Pops: *... stack*, {uint64 A}, {uint64 B}
 - Pushes: uint64
 - A is not zero or B is not zero => {0 or 1}
 
 ## ==
 
-- Opcode: 0x12 
+- Opcode: 0x12
 - Pops: *... stack*, {any A}, {any B}
 - Pushes: uint64
 - A is equal to B => {0 or 1}
 
 ## !=
 
-- Opcode: 0x13 
+- Opcode: 0x13
 - Pops: *... stack*, {any A}, {any B}
 - Pushes: uint64
 - A is not equal to B => {0 or 1}
 
 ## !
 
-- Opcode: 0x14 
+- Opcode: 0x14
 - Pops: *... stack*, uint64
 - Pushes: uint64
 - X == 0 yields 1; else 0
 
 ## len
 
-- Opcode: 0x15 
+- Opcode: 0x15
 - Pops: *... stack*, []byte
 - Pushes: uint64
 - yields length of byte value X
 
 ## itob
 
-- Opcode: 0x16 
+- Opcode: 0x16
 - Pops: *... stack*, uint64
 - Pushes: []byte
 - converts uint64 X to big endian bytes
 
 ## btoi
 
-- Opcode: 0x17 
+- Opcode: 0x17
 - Pops: *... stack*, []byte
 - Pushes: uint64
 - converts bytes X as big endian to uint64
 
-`btoi` panics if the input is longer than 8 bytes
+`btoi` panics if the input is longer than 8 bytes.
 
 ## %
 
-- Opcode: 0x18 
+- Opcode: 0x18
 - Pops: *... stack*, {uint64 A}, {uint64 B}
 - Pushes: uint64
 - A modulo B. Panic if B == 0.
 
 ## |
 
-- Opcode: 0x19 
+- Opcode: 0x19
 - Pops: *... stack*, {uint64 A}, {uint64 B}
 - Pushes: uint64
 - A bitwise-or B
 
 ## &
 
-- Opcode: 0x1a 
+- Opcode: 0x1a
 - Pops: *... stack*, {uint64 A}, {uint64 B}
 - Pushes: uint64
 - A bitwise-and B
 
 ## ^
 
-- Opcode: 0x1b 
+- Opcode: 0x1b
 - Pops: *... stack*, {uint64 A}, {uint64 B}
 - Pushes: uint64
 - A bitwise-xor B
 
 ## ~
 
-- Opcode: 0x1c 
+- Opcode: 0x1c
 - Pops: *... stack*, uint64
 - Pushes: uint64
 - bitwise invert value X
 
 ## mulw
 
-- Opcode: 0x1d 
+- Opcode: 0x1d
 - Pops: *... stack*, {uint64 A}, {uint64 B}
 - Pushes: uint64, uint64
 - A times B out to 128-bit long result as low (top) and high uint64 values on the stack
+
+## plusw
+
+- Opcode: 0x1e
+- Pops: *... stack*, {uint64 A}, {uint64 B}
+- Pushes: uint64, uint64
+- A plus B out to 128-bit long result as sum (top) and carry-bit uint64 values on the stack
+- LogicSigVersion >= 2
 
 ## intcblock
 
@@ -228,28 +245,28 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 ## intc_0
 
-- Opcode: 0x22 
+- Opcode: 0x22
 - Pops: _None_
 - Pushes: uint64
 - push constant 0 from intcblock to stack
 
 ## intc_1
 
-- Opcode: 0x23 
+- Opcode: 0x23
 - Pops: _None_
 - Pushes: uint64
 - push constant 1 from intcblock to stack
 
 ## intc_2
 
-- Opcode: 0x24 
+- Opcode: 0x24
 - Pops: _None_
 - Pushes: uint64
 - push constant 2 from intcblock to stack
 
 ## intc_3
 
-- Opcode: 0x25 
+- Opcode: 0x25
 - Pops: _None_
 - Pushes: uint64
 - push constant 3 from intcblock to stack
@@ -272,28 +289,28 @@ Overflow is an error condition which halts execution and fails the transaction. 
 
 ## bytec_0
 
-- Opcode: 0x28 
+- Opcode: 0x28
 - Pops: _None_
 - Pushes: []byte
 - push constant 0 from bytecblock to stack
 
 ## bytec_1
 
-- Opcode: 0x29 
+- Opcode: 0x29
 - Pops: _None_
 - Pushes: []byte
 - push constant 1 from bytecblock to stack
 
 ## bytec_2
 
-- Opcode: 0x2a 
+- Opcode: 0x2a
 - Pops: _None_
 - Pushes: []byte
 - push constant 2 from bytecblock to stack
 
 ## bytec_3
 
-- Opcode: 0x2b 
+- Opcode: 0x2b
 - Pops: _None_
 - Pushes: []byte
 - push constant 3 from bytecblock to stack
@@ -304,34 +321,39 @@ Overflow is an error condition which halts execution and fails the transaction. 
 - Pops: _None_
 - Pushes: []byte
 - push Args[N] value to stack by index
+- Mode: Signature
 
 ## arg_0
 
-- Opcode: 0x2d 
+- Opcode: 0x2d
 - Pops: _None_
 - Pushes: []byte
 - push Args[0] to stack
+- Mode: Signature
 
 ## arg_1
 
-- Opcode: 0x2e 
+- Opcode: 0x2e
 - Pops: _None_
 - Pushes: []byte
 - push Args[1] to stack
+- Mode: Signature
 
 ## arg_2
 
-- Opcode: 0x2f 
+- Opcode: 0x2f
 - Pops: _None_
 - Pushes: []byte
 - push Args[2] to stack
+- Mode: Signature
 
 ## arg_3
 
-- Opcode: 0x30 
+- Opcode: 0x30
 - Pops: _None_
 - Pushes: []byte
 - push Args[3] to stack
+- Mode: Signature
 
 ## txn
 
@@ -347,7 +369,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 | 0 | Sender | []byte | 32 byte address |
 | 1 | Fee | uint64 | micro-Algos |
 | 2 | FirstValid | uint64 | round number |
-| 3 | FirstValidTime | uint64 | Causes program to fail; reserved for future use. |
+| 3 | FirstValidTime | uint64 | Causes program to fail; reserved for future use |
 | 4 | LastValid | uint64 | round number |
 | 5 | Note | []byte |  |
 | 6 | Lease | []byte |  |
@@ -366,20 +388,45 @@ Overflow is an error condition which halts execution and fails the transaction. 
 | 19 | AssetSender | []byte | 32 byte address. Causes clawback of all value of asset from AssetSender if Sender is the Clawback address of the asset. |
 | 20 | AssetReceiver | []byte | 32 byte address |
 | 21 | AssetCloseTo | []byte | 32 byte address |
-| 22 | GroupIndex | uint64 | Position of this transaction within an atomic transaction group. A stand-alone transaction is implicitly element 0 in a group of 1. |
+| 22 | GroupIndex | uint64 | Position of this transaction within an atomic transaction group. A stand-alone transaction is implicitly element 0 in a group of 1 |
 | 23 | TxID | []byte | The computed ID for this transaction. 32 bytes. |
+| 24 | ApplicationID | uint64 | ApplicationID from ApplicationCall transaction. LogicSigVersion >= 2. |
+| 25 | OnCompletion | uint64 | ApplicationCall transaction on completion action. LogicSigVersion >= 2. |
+| 26 | ApplicationArgs | []byte | Arguments passed to the application in the ApplicationCall transaction. LogicSigVersion >= 2. |
+| 27 | NumAppArgs | uint64 | Number of ApplicationArgs. LogicSigVersion >= 2. |
+| 28 | Accounts | []byte | Accounts listed in the ApplicationCall transaction. LogicSigVersion >= 2. |
+| 29 | NumAccounts | uint64 | Number of Accounts. LogicSigVersion >= 2. |
+| 30 | ApprovalProgram | []byte | Approval program. LogicSigVersion >= 2. |
+| 31 | ClearStateProgram | []byte | Clear state program. LogicSigVersion >= 2. |
+| 32 | RekeyTo | []byte | 32 byte Sender's new AuthAddr. LogicSigVersion >= 2. |
+| 33 | ConfigAsset | uint64 | Asset ID in asset config transaction. LogicSigVersion >= 2. |
+| 34 | ConfigAssetTotal | uint64 | Total number of units of this asset created. LogicSigVersion >= 2. |
+| 35 | ConfigAssetDecimals | uint64 | Number of digits to display after the decimal place when displaying the asset. LogicSigVersion >= 2. |
+| 36 | ConfigAssetDefaultFrozen | uint64 | Whether the asset's slots are frozen by default or not, 0 or 1. LogicSigVersion >= 2. |
+| 37 | ConfigAssetUnitName | []byte | Unit name of the asset. LogicSigVersion >= 2. |
+| 38 | ConfigAssetName | []byte | The asset name. LogicSigVersion >= 2. |
+| 39 | ConfigAssetURL | []byte | URL. LogicSigVersion >= 2. |
+| 40 | ConfigAssetMetadataHash | []byte | 32 byte commitment to some unspecified asset metadata. LogicSigVersion >= 2. |
+| 41 | ConfigAssetManager | []byte | 32 byte address. LogicSigVersion >= 2. |
+| 42 | ConfigAssetReserve | []byte | 32 byte address. LogicSigVersion >= 2. |
+| 43 | ConfigAssetFreeze | []byte | 32 byte address. LogicSigVersion >= 2. |
+| 44 | ConfigAssetClawback | []byte | 32 byte address. LogicSigVersion >= 2. |
+| 45 | FreezeAsset | uint64 | Asset ID being frozen or un-frozen. LogicSigVersion >= 2. |
+| 46 | FreezeAssetAccount | []byte | 32 byte address of the account whose asset slot is being frozen or un-frozen. LogicSigVersion >= 2. |
+| 47 | FreezeAssetFrozen | uint64 | The new frozen value, 0 or 1. LogicSigVersion >= 2. |
 
 
 TypeEnum mapping:
 
 | Index | "Type" string | Description |
 | --- | --- | --- |
-| 0 | unknown | Unknown type. Invalid transaction. |
+| 0 | unknown | Unknown type. Invalid transaction |
 | 1 | pay | Payment |
 | 2 | keyreg | KeyRegistration |
 | 3 | acfg | AssetConfig |
 | 4 | axfer | AssetTransfer |
 | 5 | afrz | AssetFreeze |
+| 6 | appl | ApplicationCall |
 
 
 FirstValidTime causes the program to fail. The field is reserved for future use.
@@ -399,7 +446,10 @@ FirstValidTime causes the program to fail. The field is reserved for future use.
 | 1 | MinBalance | uint64 | micro Algos |
 | 2 | MaxTxnLife | uint64 | rounds |
 | 3 | ZeroAddress | []byte | 32 byte address of all zero bytes |
-| 4 | GroupSize | uint64 | Number of transactions in this atomic transaction group. At least 1. |
+| 4 | GroupSize | uint64 | Number of transactions in this atomic transaction group. At least 1 |
+| 5 | LogicSigVersion | uint64 | Maximum supported TEAL version. LogicSigVersion >= 2. |
+| 6 | Round | uint64 | Current round number. LogicSigVersion >= 2. |
+| 7 | LatestTimestamp | uint64 | Last confirmed block UNIX timestamp. Fails if negative. LogicSigVersion >= 2. |
 
 
 ## gtxn
@@ -409,7 +459,7 @@ FirstValidTime causes the program to fail. The field is reserved for future use.
 - Pushes: any
 - push field to the stack from a transaction in the current transaction group
 
-for notes on transaction fields available, see `txn`. If this transaction is _i_ in the group, `gtxn i field` is equivalent to `txn field`
+for notes on transaction fields available, see `txn`. If this transaction is _i_ in the group, `gtxn i field` is equivalent to `txn field`.
 
 ## load
 
@@ -425,6 +475,22 @@ for notes on transaction fields available, see `txn`. If this transaction is _i_
 - Pushes: _None_
 - pop a value from the stack and store to scratch space
 
+## txna
+
+- Opcode: 0x36 {uint8 transaction field index}{uint8 transaction field array index}
+- Pops: _None_
+- Pushes: any
+- push value of an array field from current transaction to stack
+- LogicSigVersion >= 2
+
+## gtxna
+
+- Opcode: 0x37 {uint8 transaction group index}{uint8 transaction field index}{uint8 transaction field array index}
+- Pops: _None_
+- Pushes: any
+- push value of a field to the stack from a transaction in the current transaction group
+- LogicSigVersion >= 2
+
 ## bnz
 
 - Opcode: 0x40 {0..0x7fff forward branch offset, big endian}
@@ -434,16 +500,233 @@ for notes on transaction fields available, see `txn`. If this transaction is _i_
 
 The `bnz` instruction opcode 0x40 is followed by two immediate data bytes which are a high byte first and low byte second which together form a 16 bit offset which the instruction may branch to. For a bnz instruction at `pc`, if the last element of the stack is not zero then branch to instruction at `pc + 3 + N`, else proceed to next instruction at `pc + 3`. Branch targets must be well aligned instructions. (e.g. Branching to the second byte of a 2 byte op will be rejected.) Branch offsets are currently limited to forward branches only, 0-0x7fff. A future expansion might make this a signed 16 bit integer allowing for backward branches and looping.
 
+At LogicSigVersion 2 it became allowed to branch to the end of the program exactly after the last instruction, removing the need for a last instruction or no-op as a branch target at the end. Branching beyond that may still fail the program.
+
+## bz
+
+- Opcode: 0x41 {0..0x7fff forward branch offset, big endian}
+- Pops: *... stack*, uint64
+- Pushes: _None_
+- branch if value X is zero
+- LogicSigVersion >= 2
+
+See `bnz` for details on how branches work. `bz` inverts the behavior of `bnz`.
+
+## b
+
+- Opcode: 0x42 {0..0x7fff forward branch offset, big endian}
+- Pops: _None_
+- Pushes: _None_
+- branch unconditionally to offset
+- LogicSigVersion >= 2
+
+See `bnz` for details on how branches work. `b` always jumps to the offset.
+
+## return
+
+- Opcode: 0x43
+- Pops: *... stack*, uint64
+- Pushes: _None_
+- use last value on stack as success value; end
+- LogicSigVersion >= 2
+
 ## pop
 
-- Opcode: 0x48 
+- Opcode: 0x48
 - Pops: *... stack*, any
 - Pushes: _None_
 - discard value X from stack
 
 ## dup
 
-- Opcode: 0x49 
+- Opcode: 0x49
 - Pops: *... stack*, any
 - Pushes: any, any
 - duplicate last value on stack
+
+## dup2
+
+- Opcode: 0x4a
+- Pops: *... stack*, {any A}, {any B}
+- Pushes: any, any, any, any
+- duplicate two last values on stack: A, B -> A, B, A, B
+- LogicSigVersion >= 2
+
+## concat
+
+- Opcode: 0x50
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: []byte
+- pop two byte strings A and B and join them, push the result
+- LogicSigVersion >= 2
+
+`concat` panics if the result would be greater than 4096 bytes.
+
+## substring
+
+- Opcode: 0x51 {uint8 start position}{uint8 end position}
+- Pops: *... stack*, []byte
+- Pushes: []byte
+- pop a byte string X. For immediate values in 0..255 N and M: extract a range of bytes from it starting at N up to but not including M, push the substring result
+- LogicSigVersion >= 2
+
+## substring3
+
+- Opcode: 0x52
+- Pops: *... stack*, {[]byte A}, {uint64 B}, {uint64 C}
+- Pushes: []byte
+- pop a byte string A and two integers B and C. Extract a range of bytes from A starting at B up to but not including C, push the substring result
+- LogicSigVersion >= 2
+
+## balance
+
+- Opcode: 0x60
+- Pops: *... stack*, uint64
+- Pushes: uint64
+- get balance for the requested account specified by Txn.Accounts[A] in microalgos. A is specified as an account index in the Accounts field of the ApplicationCall transaction
+- LogicSigVersion >= 2
+- Mode: Application
+
+## app_opted_in
+
+- Opcode: 0x61
+- Pops: *... stack*, {uint64 A}, {uint64 B}
+- Pushes: uint64
+- check if account specified by Txn.Accounts[A] opted in for the application B => {0 or 1}
+- LogicSigVersion >= 2
+- Mode: Application
+
+params: account index, application id (top of the stack on opcode entry). Return: 1 if opted in and 0 otherwise.
+
+## app_local_get
+
+- Opcode: 0x62
+- Pops: *... stack*, {uint64 A}, {[]byte B}
+- Pushes: any
+- read from account specified by Txn.Accounts[A] from local state of the current application key B => value
+- LogicSigVersion >= 2
+- Mode: Application
+
+params: account index, state key. Return: value. The value is zero if the key does not exist.
+
+## app_local_get_ex
+
+- Opcode: 0x63
+- Pops: *... stack*, {uint64 A}, {uint64 B}, {[]byte C}
+- Pushes: uint64, any
+- read from account specified by Txn.Accounts[A] from local state of the application B key C => {0 or 1 (top), value}
+- LogicSigVersion >= 2
+- Mode: Application
+
+params: account index, application id, state key. Return: did_exist flag (top of the stack, 1 if exist and 0 otherwise), value.
+
+## app_global_get
+
+- Opcode: 0x64
+- Pops: *... stack*, []byte
+- Pushes: any
+- read key A from global state of a current application => value
+- LogicSigVersion >= 2
+- Mode: Application
+
+params: state key. Return: value. The value is zero if the key does not exist.
+
+## app_global_get_ex
+
+- Opcode: 0x65
+- Pops: *... stack*, {uint64 A}, {[]byte B}
+- Pushes: uint64, any
+- read from application A global state key B => {0 or 1 (top), value}
+- LogicSigVersion >= 2
+- Mode: Application
+
+params: application id, state key. Return: value.
+
+## app_local_put
+
+- Opcode: 0x66
+- Pops: *... stack*, {uint64 A}, {[]byte B}, {any C}
+- Pushes: _None_
+- write to account specified by Txn.Accounts[A] to local state of a current application key B with value C
+- LogicSigVersion >= 2
+- Mode: Application
+
+params: account index, state key, value.
+
+## app_global_put
+
+- Opcode: 0x67
+- Pops: *... stack*, {[]byte A}, {any B}
+- Pushes: _None_
+- write key A and value B to global state of the current application
+- LogicSigVersion >= 2
+- Mode: Application
+
+## app_local_del
+
+- Opcode: 0x68
+- Pops: *... stack*, {uint64 A}, {[]byte B}
+- Pushes: _None_
+- delete from account specified by Txn.Accounts[A] local state key B of the current application
+- LogicSigVersion >= 2
+- Mode: Application
+
+params: account index, state key.
+
+## app_global_del
+
+- Opcode: 0x69
+- Pops: *... stack*, []byte
+- Pushes: _None_
+- delete key A from a global state of the current application
+- LogicSigVersion >= 2
+- Mode: Application
+
+params: state key.
+
+## asset_holding_get
+
+- Opcode: 0x70 {uint8 asset holding field index}
+- Pops: *... stack*, {uint64 A}, {uint64 B}
+- Pushes: uint64, any
+- read from account specified by Txn.Accounts[A] and asset B holding field X (imm arg) => {0 or 1 (top), value}
+- LogicSigVersion >= 2
+- Mode: Application
+
+`asset_holding_get` Fields:
+
+| Index | Name | Type | Notes |
+| --- | --- | --- | --- |
+| 0 | AssetBalance | uint64 | Amount of the asset unit held by this account |
+| 1 | AssetFrozen | uint64 | Is the asset frozen or not |
+
+
+params: account index, asset id. Return: did_exist flag (1 if exist and 0 otherwise), value.
+
+## asset_params_get
+
+- Opcode: 0x71 {uint8 asset params field index}
+- Pops: *... stack*, {uint64 A}, {uint64 B}
+- Pushes: uint64, any
+- read from account specified by Txn.Accounts[A] and asset B params field X (imm arg) => {0 or 1 (top), value}
+- LogicSigVersion >= 2
+- Mode: Application
+
+`asset_params_get` Fields:
+
+| Index | Name | Type | Notes |
+| --- | --- | --- | --- |
+| 0 | AssetTotal | uint64 | Total number of units of this asset |
+| 1 | AssetDecimals | uint64 | See AssetParams.Decimals |
+| 2 | AssetDefaultFrozen | uint64 | Frozen by default or not |
+| 3 | AssetUnitName | []byte | Asset unit name |
+| 4 | AssetName | []byte | Asset name |
+| 5 | AssetURL | []byte | URL with additional info about the asset |
+| 6 | AssetMetadataHash | []byte | Arbitrary commitment |
+| 7 | AssetManager | []byte | Manager commitment |
+| 8 | AssetReserve | []byte | Reserve address |
+| 9 | AssetFreeze | []byte | Freeze address |
+| 10 | AssetClawback | []byte | Clawback address |
+
+
+params: account index, asset id. Return: did_exist flag (1 if exist and 0 otherwise), value.

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -501,7 +501,7 @@ for notes on transaction fields available, see `txn`. If this transaction is _i_
 
 The `bnz` instruction opcode 0x40 is followed by two immediate data bytes which are a high byte first and low byte second which together form a 16 bit offset which the instruction may branch to. For a bnz instruction at `pc`, if the last element of the stack is not zero then branch to instruction at `pc + 3 + N`, else proceed to next instruction at `pc + 3`. Branch targets must be well aligned instructions. (e.g. Branching to the second byte of a 2 byte op will be rejected.) Branch offsets are currently limited to forward branches only, 0-0x7fff. A future expansion might make this a signed 16 bit integer allowing for backward branches and looping.
 
-At LogicSigVersion 2 it became allowed to branch to the end of the program exactly after the last instruction, removing the need for a last instruction or no-op as a branch target at the end. Branching beyond that may still fail the program. In other words, for a TEAL program with N bytes, a bnz to byte N (with 0-indexing) is illegal before LogicSigVersion 2 and is legal after it.
+At LogicSigVersion 2 it became allowed to branch to the end of the program exactly after the last instruction: bnz to byte N (with 0-indexing) was illegal for a TEAL program with N bytes before LogicSigVersion 2, and is legal after it. This change eliminates the need for a last instruction of no-op as a branch target at the end. (Branching beyond the end--in other words, to a byte larger than N--is still illegal and will cause the program to fail.)
 
 ## bz
 


### PR DESCRIPTION
 - Add versioning to TEAL programs.  Old TEAL program versions remain
   supported under version 1.

   - Add a #pragma assembler directive for switching between TEAL
     program versions.

 - Add execution modes to TEAL, with old TEAL programs executed in the
   stateless mode.

 - Add TEAL version 2, which introduce the changes below.

 - Add the ability to access the current TEAL version.

 - Add a new stateful execution mode to TEAL, which allows it to
   access data resident on chain.  This new mode changes the set of
   available opcodes and has different program cost parameters.

   - Add opcodes and constants supporting this mode, which include
     opcodes to read from on-chain "application" state, opcodes to
     read Algo balances, and opcodes to read asset balances.

   - Add the ability to read the current round in stateful TEAL.

   - Add the ability to read the latest-confirmed block header
     timestamp in stateful TEAL.

 - Add the ability to read the RekeyTo transaction field.

   - Note: TEAL programs with version 1 fail if this field is not the
     zero address.

 - Add opcodes to concatenate and slice byte strings.

 - Add additional program flow opcodes for conditional and
   unconditional branching.

 - Add an opcode to duplicate two values on the stack.

 - Add a wide addition opcode, which preserves the carry bit.

 - Support string literals (e.g., byte "string literal") in the
   assembler.


Co-authored-by: Brian Olson <brian.olson@algorand.com>
Co-authored-by: Pavel Zbitskii  <pavel@algorand.com>
Co-authored-by: Max Justicz <max@algorand.com>