### PR TITLE
update the NumProposers from 9->20, to reflect current code parameters

### DIFF
--- a/dev/abft.md
+++ b/dev/abft.md
@@ -210,7 +210,7 @@ The following functions are defined on $s$:
 $$
 \CommitteeSize(s) = \left\{
 \begin{array}{rl}
-      9 & : s = \Propose \\
+     20 & : s = \Propose \\
    2990 & : s = \Soft \\
    1500 & : s = \Cert \\
     500 & : s = \Late \\


### PR DESCRIPTION
## Solution

The number of proposers in the spec doesn't align with the number of proposers we current use in our codebase.
This change update the spec to align with the codebase.
https://github.com/algorand/go-algorand/blob/master/config/consensus.go#L632