### PR TITLE
Merkle trees for commitment to the payset in a block

### DIFF
--- a/dev/crypto.md
+++ b/dev/crypto.md
@@ -209,10 +209,11 @@ def verify(elems, proof, root):
     sibling = pos ^ 1
     if i+1 < len(elems) and elems[i+1].pos == sibling:
       sibhash = elems[i+1].hash
-      i++
+      i += 2
     else:
       sibhash = proof[0]
       proof = proof[1:]
+      i += 1
     if pos&1 == 0:
       h = H("MA" + poshash + sibhash)
     else:

--- a/dev/crypto.md
+++ b/dev/crypto.md
@@ -52,7 +52,8 @@ below specifies each prefix (in quotation marks):
     - "BH": A _Block Header_.
     - "BR": A _Balance Record_.
     - "GE": A _Genesis_ configuration.
-    - "PF": A _Payset_ encoded as a flat list.
+    - "STIB": A _SignedTxnInBlock_ that appears as part of the leaf in the Merkle tree of transactions.
+    - "TL": A leaf in the Merkle tree of transactions.
     - "TX": A _Transaction_.
  - In the [Algorand Byzantine Fault Tolerance protocol][abft-spec]:
     - "AS": An _Agreement Selector_, which is also a [VRF][Verifiable

--- a/dev/crypto.md
+++ b/dev/crypto.md
@@ -228,6 +228,6 @@ def verify(elems, proof, root):
 [ledger-spec]: https://github.com/algorand/spec/ledger.md
 [abft-spec]: https://github.com/algorand/spec/abft.md
 
-[sha]: TODO-sha
-[ed25519]: TODO-ed25519
+[sha]: https://doi.org/10.6028/NIST.FIPS.180-4
+[ed25519]: https://tools.ietf.org/html/rfc8032
 [msgpack]: https://github.com/msgpack/msgpack/blob/master/spec.md

--- a/dev/crypto.md
+++ b/dev/crypto.md
@@ -9,8 +9,7 @@ abstract: >
 ---
 
 
-Representation
-==============
+# Representation
 
 As a preliminary for guaranteeing cryptographic data integrity,
 Algorand represents all inputs to cryptographic functions (i.e., a
@@ -18,8 +17,7 @@ cryptographic hash, signature, or verifiable random function) via a
 canonical and domain-separated representation.
 
 
-Canonical Msgpack
------------------
+## Canonical Msgpack
 
 Algorand uses a version of [msgpack][msgpack] to produce canonical
 encodings of data.  Algorand's msgpack encodings are valid msgpack
@@ -40,8 +38,7 @@ A canonical msgpack encoding in Algorand must follow these rules:
     older msgpack version that had no "bin" family).
 
 
-Domain Separation
------------------
+## Domain Separation
 
 Before an object is input to some cryptographic function, it is
 prepended with a multi-character domain-separating prefix.  The list
@@ -49,7 +46,8 @@ below specifies each prefix (in quotation marks):
 
  - For cryptographic primitives:
     - "OT1" and "OT2": The first and second layers of keys used for
-      [ephemeral signatures](Ephemeral-key Signatures).
+      [ephemeral signatures](#ephemeral-key-signature).
+    - "MA": An internal node in a [Merkle tree](#merkle-tree).
  - In the [Algorand Ledger][ledger-spec]:
     - "BH": A _Block Header_.
     - "BR": A _Balance Record_.
@@ -80,8 +78,7 @@ below specifies each prefix (in quotation marks):
        - "aS": A _Settlement_.
 
 
-Hash Function
-=============
+# Hash Function
 
 Algorand uses the [SHA-512/256 algorithm][sha] as its primary
 cryptographic hash function.
@@ -91,24 +88,139 @@ for the Byzantine Fault Tolerance protocol, and (2) rerandomize its
 random seed.
 
 
-Digital Signature
-=================
+# Digital Signature
 
 Algorand uses the [ed25519][ed25519] digital signature scheme to sign
 data.
 
 
-Ephemeral-key Signature
------------------------
+## Ephemeral-key Signature
 
 
 
-Verifiable Random Function
-==========================
+# Verifiable Random Function
 
 
-Cryptographic Sortition
------------------------
+## Cryptographic Sortition
+
+
+# Merkle tree
+
+Algorand uses a Merkle tree to commit to an array of elements and
+to generate and verify proofs of elements against such a commitment.
+The Merkle tree algorithm is defined for a dense array of N elements
+numbered 0 through N-1.  We now describe how to commit to an array (to
+produce a commitment in the form of a root hash), what a proof looks like,
+and how to verifying a proof for one or more elements.
+
+Since there is at most one valid proof that can be efficiently computed
+for a given position, element, and root commitment, we do not formally
+define an algorithm for generating a proof.  Any algorithm that
+generates a valid proof (i.e., which passes verification) is correct.
+A reasonable strategy for generating a proof is to follow the logic
+of the proof verifier and fill in the expected left- and right-sibling
+values in the proof based on the internal nodes of the Merkle tree built
+up during commitment.
+
+## Commitment
+
+To commit to an array of N elements, each element is first hashed
+to produce a 32-byte hash value, together with the appropriate
+[domain-separation prefix](#domain-separation); this produces a list
+of N hashes.  If N=0, then the commitment is all-zero (i.e., 32 zero
+bytes).  Otherwise, the list of N 32-byte values is repeatedly reduced
+to a shorter list, as described below, until exactly one 32-byte value
+remains; at that point, this resulting 32-byte value is the commitment.
+
+The reduction procedure takes pairs of even-and-odd-indexed values in
+the list (for instance, the values at positions 0 and 1; the values at
+positions 2 and 3; and so on) and hashes each pair to produce a single
+value in the reduced list (respectively, at position 0; at position
+1; and so on).  To hash two values into a single value, the reduction
+procedure concatenates the domain-separation prefix "MA" together with
+the two values (in the order they appear in the list), and then applies
+the hash function.  When a list has an odd number of values, the last
+value is paired together with an all-zero value (i.e., 32 zero bytes).
+
+The pseudocode for the commitment algorithm is as follows:
+
+```
+def commit(elems):
+  hashes = [H(elem) for elem in elems]
+  return reduce(hashes)
+
+def reduce(hashes):
+  if len(hashes) == 0:
+    return [0 for _ in range(32)]
+  if len(hashes) == 1:
+    return hashes[0]
+  nexthashes = []
+  while len(hashes) > 0:
+    left = hashes[0]
+    right = hashes[1] if len(hashes) > 1 else [0 for _ in range(32)]
+    hashes = hashes[2:]
+    nexthashes.append(H("MA" + left + right))
+  return reduce(nexthashes)
+```
+
+## Proofs
+
+Logically, to verify that an element appears at some position P in the
+array, the verifier runs a variant of the commit procedure to compute
+a candidate root hash, and then checks if the resulting root hash is
+equal to the expected commitment value.  The key difference is that the
+verifier does not have access to the entire list of committed elements;
+the verifier just has some subset of elemens (one or more), along with the
+positions at which these elements appear.  Thus, the verifier needs to
+know the siblings (the `left` and `right` values used in the `reduce()`
+function above) to compute its candidate root hash.  The list of these
+siblings constitutes the proof; thus, a proof is a list of zero or more
+32-byte hash values.  Algorand defines a deterministic order in which
+the verification procedure expects to find siblings in this proof, so no
+additional information is required as part of the proof (in particular,
+no information about which part of the Merkle tree each proof element
+corresponds to).
+
+## Verifying a proof
+
+The following pseudocode defines the logic for verifying a proof (a
+list of 32-byte hashes) for one or more elements, specified as a list
+of position-element pairs, sorted by position in the array, against a
+root commitment.  The function `verify` returns `True` if `proof` is a
+valid proof for all elements in `elems` being present at their positions
+in the array committed to by `root`.  (The pseudocode might raise an
+exception due to accessing the proof past the end; this is equivalent
+to returning `False`.)  The function implements a variant of `reduce()`
+for a sparse array, rather than a fully-populated one.
+
+```
+def verify(elems, proof, root):
+  if len(elems) == 0:
+    return len(proof) == 0
+  if len(elems) == 1 and len(proof) == 0:
+    return elems[0].pos == 0 && elems[0].hash == root
+
+  i = 0
+  nextelems = []
+  while i < len(elems):
+    pos = elems[i].pos
+    poshash = elems[i].hash
+    sibling = pos ^ 1
+    if i+1 < len(elems) and elems[i+1].pos == sibling:
+      sibhash = elems[i+1].hash
+      i++
+    else:
+      sibhash = proof[0]
+      proof = proof[1:]
+    if pos&1 == 0:
+      h = H("MA" + poshash + sibhash)
+    else:
+      h = H("MA" + sibhash + poshash)
+    nextelems.append({"pos": pos/2, "hash": h})
+
+  return verify(nextelems, proof, root)
+```
+
 
 
 [ledger-spec]: https://github.com/algorand/spec/ledger.md
@@ -116,4 +228,4 @@ Cryptographic Sortition
 
 [sha]: TODO-sha
 [ed25519]: TODO-ed25519
-[msgpack]: TODO-msgpack
+[msgpack]: https://github.com/msgpack/msgpack/blob/master/spec.md

--- a/dev/crypto.md
+++ b/dev/crypto.md
@@ -8,8 +8,9 @@ abstract: >
   primitives.
 ---
 
+# Algorand Cryptographic Primitive Specification
 
-# Representation
+## Representation
 
 As a preliminary for guaranteeing cryptographic data integrity,
 Algorand represents all inputs to cryptographic functions (i.e., a
@@ -17,7 +18,7 @@ cryptographic hash, signature, or verifiable random function) via a
 canonical and domain-separated representation.
 
 
-## Canonical Msgpack
+### Canonical Msgpack
 
 Algorand uses a version of [msgpack][msgpack] to produce canonical
 encodings of data.  Algorand's msgpack encodings are valid msgpack
@@ -38,7 +39,7 @@ A canonical msgpack encoding in Algorand must follow these rules:
     older msgpack version that had no "bin" family).
 
 
-## Domain Separation
+### Domain Separation
 
 Before an object is input to some cryptographic function, it is
 prepended with a multi-character domain-separating prefix.  The list
@@ -79,7 +80,7 @@ below specifies each prefix (in quotation marks):
        - "aS": A _Settlement_.
 
 
-# Hash Function
+## Hash Function
 
 Algorand uses the [SHA-512/256 algorithm][sha] as its primary
 cryptographic hash function.
@@ -89,23 +90,23 @@ for the Byzantine Fault Tolerance protocol, and (2) rerandomize its
 random seed.
 
 
-# Digital Signature
+## Digital Signature
 
 Algorand uses the [ed25519][ed25519] digital signature scheme to sign
 data.
 
 
-## Ephemeral-key Signature
+### Ephemeral-key Signature
 
 
 
-# Verifiable Random Function
+## Verifiable Random Function
 
 
-## Cryptographic Sortition
+### Cryptographic Sortition
 
 
-# Merkle tree
+## Merkle tree
 
 Algorand uses a Merkle tree to commit to an array of elements and
 to generate and verify proofs of elements against such a commitment.
@@ -123,7 +124,7 @@ of the proof verifier and fill in the expected left- and right-sibling
 values in the proof based on the internal nodes of the Merkle tree built
 up during commitment.
 
-## Commitment
+### Commitment
 
 To commit to an array of N elements, each element is first hashed
 to produce a 32-byte hash value, together with the appropriate
@@ -145,7 +146,7 @@ value is paired together with an all-zero value (i.e., 32 zero bytes).
 
 The pseudocode for the commitment algorithm is as follows:
 
-```
+```python
 def commit(elems):
   hashes = [H(elem) for elem in elems]
   return reduce(hashes)
@@ -164,7 +165,7 @@ def reduce(hashes):
   return reduce(nexthashes)
 ```
 
-## Proofs
+### Proofs
 
 Logically, to verify that an element appears at some position P in the
 array, the verifier runs a variant of the commit procedure to compute
@@ -182,7 +183,7 @@ additional information is required as part of the proof (in particular,
 no information about which part of the Merkle tree each proof element
 corresponds to).
 
-## Verifying a proof
+### Verifying a proof
 
 The following pseudocode defines the logic for verifying a proof (a
 list of 32-byte hashes) for one or more elements, specified as a list
@@ -194,7 +195,7 @@ exception due to accessing the proof past the end; this is equivalent
 to returning `False`.)  The function implements a variant of `reduce()`
 for a sparse array, rather than a fully-populated one.
 
-```
+```python
 def verify(elems, proof, root):
   if len(elems) == 0:
     return len(proof) == 0

--- a/dev/ledger.md
+++ b/dev/ledger.md
@@ -787,11 +787,11 @@ A value delta is composed of three fields:
 Each block contains a _transaction sequence_, an ordered sequence of
 transactions in that block.  The transaction sequence of block $r$ is denoted
 $\TxSeq_r$.  Each valid block contains a _transaction commitment_ $\TxCommit_r$
-which is the commitment to this sequence (a hash of the msgpack encoding of the
-sequence).
-
-There are two differences between how a standalone transaction is encoded,
-and how it appears in the block:
+which is a Merkle tree commitment to this sequence.  The leaves in the Merkle
+tree are hashed as $$\Hash("TL", txid, stibhash)$$.  The txid value is the
+32-byte transaction identifier.  The stibhash value is a 32-byte hash of the
+signed transaction and ApplyData for the transaction, hashed with the
+domain-separation prefix `STIB`, and encoded as follows:
 
 - Transactions in a block are encoded in a slightly different way than
   standalone transactions, for efficiency:


### PR DESCRIPTION
This PR describes the specifics of our Merkle tree construction, and describes how that Merkle tree is used to commit to the list of transactions in a block.