### PR TITLE
2021 Q2 updates (TEAL4, ASA URL, Program Sizes...)

### DIFF
--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -220,6 +220,8 @@ Some of these have immediate data in the byte or bytes after the opcode.
 | `global f` | push value from globals to stack |
 | `load i` | copy a value from scratch space to the stack |
 | `store i` | pop a value from the stack and store to scratch space |
+| `gload t i` | push Ith scratch space index of the Tth transaction in the current group |
+| `gloads i` | push Ith scratch space index of the Ath transaction in the current group |
 
 **Transaction Fields**
 
@@ -281,6 +283,7 @@ Some of these have immediate data in the byte or bytes after the opcode.
 | 53 | GlobalNumByteSlice | uint64 | Number of global state byteslices in ApplicationCall. LogicSigVersion >= 3. |
 | 54 | LocalNumUint | uint64 | Number of local state integers in ApplicationCall. LogicSigVersion >= 3. |
 | 55 | LocalNumByteSlice | uint64 | Number of local state byteslices in ApplicationCall. LogicSigVersion >= 3. |
+| 56 | AppProgramExtraPages | uint64 |  |
 
 
 Additional details in the [opcodes document](TEAL_opcodes.md#txn) on the `txn` op.

--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -151,7 +151,7 @@ For three-argument ops, `A` is the element two below the top, `B` is the penulti
 | `substring3` | pop a byte-array A and two integers B and C. Extract a range of bytes from A starting at B up to but not including C, push the substring result. If C < B, or either is larger than the array length, the program fails |
 
 These opcodes take byte-array values that are interpreted as
-big-endian unsigned integers.  For mathematical opeartors, the
+big-endian unsigned integers.  For mathematical operators, the
 returned values are the shortest byte-array that can represent the
 returned value.  For example, the zero value is the empty
 byte-array. For comparison operators, the returned value is a uint64

--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -124,6 +124,11 @@ For two-argument ops, `A` is the previous element on the stack and `B` is the la
 | `>=` | A greater than or equal to B => {0 or 1} |
 | `&&` | A is not zero and B is not zero => {0 or 1} |
 | `\|\|` | A is not zero or B is not zero => {0 or 1} |
+| `shl` | A times 2^B, modulo 2^64 |
+| `shr` | A divided by 2^B |
+| `sqrt` | The largest integer X such that X^2 <= A |
+| `log2` | The largest integer X such that 2^X <= A |
+| `exp` | A raised to the Bth power. Panic if A == B == 0 and on overflow |
 | `==` | A is equal to B => {0 or 1} |
 | `!=` | A is not equal to B => {0 or 1} |
 | `!` | X == 0 yields 1; else 0 |
@@ -137,6 +142,8 @@ For two-argument ops, `A` is the previous element on the stack and `B` is the la
 | `~` | bitwise invert value X |
 | `mulw` | A times B out to 128-bit long result as low (top) and high uint64 values on the stack |
 | `addw` | A plus B out to 128-bit long result as sum (top) and carry-bit uint64 values on the stack |
+| `divmodw` | Pop four uint64 values.  The deepest two are interpreted as a uint128 dividend (deepest value is high word), the top two are interpreted as a uint128 divisor.  Four uint64 values are pushed to the stack. The deepest two are the quotient (deeper value is the high uint64). The top two are the remainder, low bits on top. |
+| `expw` | A raised to the Bth power as a 128-bit long result as low (top) and high uint64 values on the stack. Panic if A == B == 0 or if the results exceeds 2^128-1 |
 | `getbit` | pop a target A (integer or byte-array), and index B. Push the Bth bit of A. |
 | `setbit` | pop a target A, index B, and bit C. Set the Bth bit of A to C, and push the result |
 | `getbyte` | pop a byte-array A and integer B. Extract the Bth byte of A and push it as an integer |
@@ -305,6 +312,8 @@ Asset fields include `AssetHolding` and `AssetParam` fields that are used in `as
 | `swap` | swaps two last values on stack: A, B -> B, A |
 | `select` | selects one of two values based on top-of-stack: A, B, C -> (if C != 0 then B else A) |
 | `assert` | immediately fail unless value X is a non-zero number |
+| `callsub target` | branch unconditionally to TARGET, saving the next instruction on the call stack |
+| `retsub` | pop the top instruction from the call stack and branch to it |
 
 ### State Access
 

--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -360,8 +360,8 @@ Asset fields include `AssetHolding` and `AssetParam` fields that are used in `as
 
 | Op | Description |
 | --- | --- |
-| `balance` | get balance account A, in microalgos. The balance is observed after the effects of previous transactions in the group, and after the fee for the current transaction is deducted. |
-| `min_balance` | get minimum required balance account A, in microalgos. Required balance is affected by [ASA](https://developer.algorand.org/docs/features/asa/#assets-overview) and [App](https://developer.algorand.org/docs/features/asc1/stateful/#minimum-balance-requirement-for-a-smart-contract) usage. When creating or opting into an app, the minimum balance grows before the app code runs, therefore the increase is visible there. When deleting or closing out, the minimum balance decreases after the app executes. |
+| `balance` | get balance for account A, in microalgos. The balance is observed after the effects of previous transactions in the group, and after the fee for the current transaction is deducted. |
+| `min_balance` | get minimum required balance for account A, in microalgos. Required balance is affected by [ASA](https://developer.algorand.org/docs/features/asa/#assets-overview) and [App](https://developer.algorand.org/docs/features/asc1/stateful/#minimum-balance-requirement-for-a-smart-contract) usage. When creating or opting into an app, the minimum balance grows before the app code runs, therefore the increase is visible there. When deleting or closing out, the minimum balance decreases after the app executes. |
 | `app_opted_in` | check if account A opted in for the application B => {0 or 1} |
 | `app_local_get` | read from account A from local state of the current application key B => value |
 | `app_local_get_ex` | read from account A from local state of the application B key C => [*... stack*, value, 0 or 1] |

--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -122,7 +122,7 @@ For two-argument ops, `A` is the previous element on the stack and `B` is the la
 | `shl` | A times 2^B, modulo 2^64 |
 | `shr` | A divided by 2^B |
 | `sqrt` | The largest integer X such that X^2 <= A |
-| `log2` | The largest integer X such that 2^X <= A |
+| `bitlen` | The index of the highest bit in A. If A is a byte-array, it is interpreted as a big-endian unsigned integer |
 | `exp` | A raised to the Bth power. Panic if A == B == 0 and on overflow |
 | `==` | A is equal to B => {0 or 1} |
 | `!=` | A is not equal to B => {0 or 1} |
@@ -174,8 +174,6 @@ array is interpeted as though left padded with zeros until it is the
 same length as the other input.  The returned values are the same
 length as the longest input.  Therefore, unlike array arithmetic,
 these results may contain leading zero bytes.
-
-Input lengths are limited to maximum length 64.
 
 | Op | Description |
 | --- | --- |

--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -24,7 +24,7 @@ In addition to the stack there are 256 positions of scratch space, also uint64-b
 ## Execution Modes
 
 Starting from version 2 TEAL evaluator can run programs in two modes:
-1. LogigSig (stateless)
+1. LogicSig (stateless)
 2. Application run (stateful)
 
 Differences between modes include:

--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -35,7 +35,7 @@ A program can either authorize some delegated action on a normal private key sig
 * If the account has signed the program (an ed25519 signature on "Program" concatenated with the program bytes) then if the program returns true the transaction is authorized as if the account had signed it. This allows an account to hand out a signed program so that other users can carry out delegated actions which are approved by the program.
 * If the SHA512_256 hash of the program (prefixed by "Program") is equal to the transaction Sender address then this is a contract account wholly controlled by the program. No other signature is necessary or possible. The only way to execute a transaction against the contract account is for the program to approve it.
 
-The TEAL bytecode plus the length of any Args must add up to less than 1000 bytes (consensus parameter LogicSigMaxSize). Each TEAL op has an associated cost and the program cost must total less than 20000 (consensus parameter LogicSigMaxCost). Most ops have a cost of 1, but a few slow crypto ops are much higher. Prior to v4, program costs was estimated as the static sum of all opcode costs in a program (ignoring conditionals that might skip some code).  Beginning with v4, a program's cost is tracked dynamically, while being evaluated. If the program exceeds its budget, it fails.
+The TEAL bytecode plus the length of any Args must add up to less than 1000 bytes (consensus parameter LogicSigMaxSize). Each TEAL op has an associated cost and the program cost must total less than 20000 (consensus parameter LogicSigMaxCost). Most ops have a cost of 1, but a few slow crypto ops are much higher. Prior to v4, program costs was estimated as the static sum of all opcode costs in a program (ignoring conditionals that might skip some code). Beginning with v4, a program's cost is tracked dynamically, while being evaluated. If the program exceeds its budget, it fails.
 
 ## Execution modes
 
@@ -149,8 +149,10 @@ For two-argument ops, `A` is the previous element on the stack and `B` is the la
 
 Opcodes prefixed with `b` are intended to take and return byteslice
 values that are interpretted as big-endian unsigned integers.
-Returned values are as the shortest byteslice that can represent the
+Returned values are the shortest byteslice that can represent the
 returned value.  For example, the zero value is the empty byteslice.
+
+Input lengths are limited to 64, which represents a 512 bit unsigned integer.
 
 | Op | Description |
 | --- | --- |
@@ -427,3 +429,4 @@ Design and implementation limitations to be aware of with various versions of TE
 * TEAL cannot know exactly what time its transaction is committed.
 * TEAL cannot loop prior to v4. In v3 and prior, the branch instructions `bnz` "branch if not zero", `bz` "branch if zero" and `b` "branch" can only branch forward so as to skip some code.
 * Until v4, TEAL had no notion of subroutines (and therefore no recursion). As of v4, use `callsub` and `retsub`.
+* TEAL cannot make indirect jumps. `b`, `bz`, `bnz`, and `callsub` jump to an immediately specified address, and `retsub` jumps to the address currently on the top of the call stack, which is manipulated only by previous calls to `callsub`.

--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -152,6 +152,28 @@ For two-argument ops, `A` is the previous element on the stack and `B` is the la
 | `substring s e` | pop a byte-array A. For immediate values in 0..255 S and E: extract a range of bytes from A starting at S up to but not including E, push the substring result. If E < S, or either is larger than the array length, the program fails |
 | `substring3` | pop a byte-array A and two integers B and C. Extract a range of bytes from A starting at B up to but not including C, push the substring result. If C < B, or either is larger than the array length, the program fails |
 
+Opcodes prefixed with `b` are intended to take and return byteslice
+values that are interpretted as big-endian unsigned integers.
+Returned values are as the shortest byteslice that can represent the
+returned value.  For example, the zero value is the empty byteslice.
+
+| Op | Description |
+| --- | --- |
+| `b+` | A plus B, where A and B are byteslices interpreted as big-endian unsigned integers |
+| `b-` | A minus B, where A and B are byteslices interpreted as big-endian unsigned integers. Panic on underflow. |
+| `b/` | A divided by B, where A and B are byteslices interpreted as big-endian unsigned integers. Panic if B is zero. |
+| `b*` | A times B, where A and B are byteslices interpreted as big-endian unsigned integers. |
+| `b<` | A is less than B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1} |
+| `b>` | A is greater than B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1} |
+| `b<=` | A is less than or equal to B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1} |
+| `b>=` | A is greater than or equal to B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1} |
+| `b==` | A is equals to B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1} |
+| `b!=` | A is not equal to B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1} |
+| `b%` | A modulo B, where A and B are byteslices interpreted as big-endian unsigned integers. Panic if B is zero. |
+| `b\|` | A bitwise-or B, where A and B are byteslices interpreted as big-endian unsigned integers. |
+| `b&` | A bitwise-and B, where A and B are byteslices interpreted as big-endian unsigned integers. |
+| `b^` | A bitwise-xor B, where A and B are byteslices interpreted as big-endian unsigned integers. |
+
 ### Loading Values
 
 Opcodes for getting data onto the stack.

--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -224,6 +224,8 @@ Some of these have immediate data in the byte or bytes after the opcode.
 | `store i` | pop a value from the stack and store to scratch space |
 | `gload t i` | push Ith scratch space index of the Tth transaction in the current group |
 | `gloads i` | push Ith scratch space index of the Ath transaction in the current group |
+| `gaid t` | push the ID of the asset or application created in the Tth transaction of the current group |
+| `gaids` | push the ID of the asset or application created in the Ath transaction of the current group |
 
 **Transaction Fields**
 
@@ -285,7 +287,7 @@ Some of these have immediate data in the byte or bytes after the opcode.
 | 53 | GlobalNumByteSlice | uint64 | Number of global state byteslices in ApplicationCall. LogicSigVersion >= 3. |
 | 54 | LocalNumUint | uint64 | Number of local state integers in ApplicationCall. LogicSigVersion >= 3. |
 | 55 | LocalNumByteSlice | uint64 | Number of local state byteslices in ApplicationCall. LogicSigVersion >= 3. |
-| 56 | AppProgramExtraPages | uint64 |  |
+| 56 | ExtraProgramPages | uint64 | Number of additional pages for each of the application's approval and clear state programs. An ExtraProgramPages of 1 means 2048 more total bytes, or 1024 for each program. LogicSigVersion >= 4. |
 
 
 Additional details in the [opcodes document](TEAL_opcodes.md#txn) on the `txn` op.

--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -147,29 +147,43 @@ For two-argument ops, `A` is the previous element on the stack and `B` is the la
 | `substring s e` | pop a byte-array A. For immediate values in 0..255 S and E: extract a range of bytes from A starting at S up to but not including E, push the substring result. If E < S, or either is larger than the array length, the program fails |
 | `substring3` | pop a byte-array A and two integers B and C. Extract a range of bytes from A starting at B up to but not including C, push the substring result. If C < B, or either is larger than the array length, the program fails |
 
-Opcodes prefixed with `b` are intended to take and return byteslice
-values that are interpretted as big-endian unsigned integers.
-Returned values are the shortest byteslice that can represent the
-returned value.  For example, the zero value is the empty byteslice.
+These opcodes take and return byte-array values that are interpreted
+as big-endian unsigned integers.  Returned values are the shortest
+byte-array that can represent the returned value.  For example, the
+zero value is the empty byte-array.
 
-Input lengths are limited to 64, which represents a 512 bit unsigned integer.
+Input lengths are limited to maximum length 64, which represents a 512
+bit unsigned integer.
 
 | Op | Description |
 | --- | --- |
-| `b+` | A plus B, where A and B are byteslices interpreted as big-endian unsigned integers |
-| `b-` | A minus B, where A and B are byteslices interpreted as big-endian unsigned integers. Panic on underflow. |
-| `b/` | A divided by B, where A and B are byteslices interpreted as big-endian unsigned integers. Panic if B is zero. |
-| `b*` | A times B, where A and B are byteslices interpreted as big-endian unsigned integers. |
-| `b<` | A is less than B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1} |
-| `b>` | A is greater than B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1} |
-| `b<=` | A is less than or equal to B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1} |
-| `b>=` | A is greater than or equal to B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1} |
-| `b==` | A is equals to B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1} |
-| `b!=` | A is not equal to B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1} |
-| `b%` | A modulo B, where A and B are byteslices interpreted as big-endian unsigned integers. Panic if B is zero. |
-| `b\|` | A bitwise-or B, where A and B are byteslices interpreted as big-endian unsigned integers. |
-| `b&` | A bitwise-and B, where A and B are byteslices interpreted as big-endian unsigned integers. |
-| `b^` | A bitwise-xor B, where A and B are byteslices interpreted as big-endian unsigned integers. |
+| `b+` | A plus B, where A and B are byte-arrays interpreted as big-endian unsigned integers |
+| `b-` | A minus B, where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic on underflow. |
+| `b/` | A divided by B, where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic if B is zero. |
+| `b*` | A times B, where A and B are byte-arrays interpreted as big-endian unsigned integers. |
+| `b<` | A is less than B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1} |
+| `b>` | A is greater than B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1} |
+| `b<=` | A is less than or equal to B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1} |
+| `b>=` | A is greater than or equal to B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1} |
+| `b==` | A is equals to B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1} |
+| `b!=` | A is not equal to B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1} |
+| `b%` | A modulo B, where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic if B is zero. |
+
+These opcodes operate on the bits of byte-array values.  The shorter
+array is interpeted as though left padded with zeros until it is the
+same length as the other input.  The returned values are the same
+length as the longest input.  Therefore, unlike array arithmetic,
+these results may contain leading zero bytes.
+
+Input lengths are limited to maximum length 64.
+
+| Op | Description |
+| --- | --- |
+| `b\|` | A bitwise-or B, where A and B are byte-arrays, zero-left extended to the greater of their lengths |
+| `b&` | A bitwise-and B, where A and B are byte-arrays, zero-left extended to the greater of their lengths |
+| `b^` | A bitwise-xor B, where A and B are byte-arrays, zero-left extended to the greater of their lengths |
+| `b~` | A with all bits inverted |
+
 
 ### Loading Values
 
@@ -193,6 +207,7 @@ Some of these have immediate data in the byte or bytes after the opcode.
 | `bytec_2` | push constant 2 from bytecblock to stack |
 | `bytec_3` | push constant 3 from bytecblock to stack |
 | `pushbytes bytes` | push the following program bytes to the stack |
+| `bzero` | push a byte-array of length A, containing all zero bytes |
 | `arg n` | push Nth LogicSig argument to stack |
 | `arg_0` | push LogicSig argument 0 to stack |
 | `arg_1` | push LogicSig argument 1 to stack |

--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -21,7 +21,7 @@ The maximum stack depth is currently 1000.
 
 In addition to the stack there are 256 positions of scratch space, also uint64-bytes union values, accessed by the `load` and `store` ops moving data from or to scratch space, respectively.
 
-## Execution modes
+## Execution Modes
 
 Starting from version 2 TEAL evaluator can run programs in two modes:
 1. LogigSig (stateless)
@@ -222,15 +222,15 @@ Some of these have immediate data in the byte or bytes after the opcode.
 | `gtxn t f` | push field F of the Tth transaction in the current group |
 | `txna f i` | push Ith value of the array field F of the current transaction |
 | `gtxna t f i` | push Ith value of the array field F from the Tth transaction in the current group |
-| `gtxns f` | push field F of the Ath transaction in the current group |
-| `gtxnsa f i` | push Ith value of the array field F from the Ath transaction in the current group |
+| `gtxns f` | push field F of the Xth transaction in the current group |
+| `gtxnsa f i` | push Ith value of the array field F from the Xth transaction in the current group |
 | `global f` | push value from globals to stack |
 | `load i` | copy a value from scratch space to the stack |
 | `store i` | pop a value from the stack and store to scratch space |
 | `gload t i` | push Ith scratch space index of the Tth transaction in the current group |
-| `gloads i` | push Ith scratch space index of the Ath transaction in the current group |
-| `gaid t` | push the ID of the asset or application created in the Tth transaction of the current group, or fail if nothing was created in that transaction |
-| `gaids` | push the ID of the asset or application created in the Ath transaction of the current group, or fail if nothing was created in that transaction |
+| `gloads i` | push Ith scratch space index of the Xth transaction in the current group |
+| `gaid t` | push the ID of the asset or application created in the Tth transaction of the current group |
+| `gaids` | push the ID of the asset or application created in the Xth transaction of the current group |
 
 **Transaction Fields**
 

--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -44,19 +44,19 @@ Starting from version 2 TEAL evaluator can run programs in two modes:
 2. Application run (stateful)
 
 Differences between modes include:
-1. Max program length (consensus parameters LogicSigMaxSize, MaxApprovalProgramLen and MaxClearStateProgramLen)
+1. Max program length (consensus parameters LogicSigMaxSize, MaxAppProgramLen & MaxExtraAppProgramPages)
 2. Max program cost (consensus parameters LogicSigMaxCost, MaxAppProgramCost)
-3. Opcodes availability. For example, all stateful operations are only available in stateful mode. Refer to [opcodes document](TEAL_opcodes.md) for details.
+3. Opcode availability. For example, all stateful operations are only available in stateful mode. Refer to [opcodes document](TEAL_opcodes.md) for details.
 
 ## Constants
 
-Constants are loaded into the environment into storage separate from the stack. They can then be pushed onto the stack by referring to the type and index. This makes for efficient re-use of byte constants used for account addresses, etc.
+Constants are loaded into the environment into storage separate from the stack. They can then be pushed onto the stack by referring to the type and index. This makes for efficient re-use of byte constants used for account addresses, etc. Constants that are not reused can be pushed with `pushint` or `pushbytes`.
 
 The assembler will hide most of this, allowing simple use of `int 1234` and `byte 0xcafed00d`. These constants will automatically get assembled into int and byte pages of constants, de-duplicated, and operations to load them from constant storage space inserted.
 
 Constants are loaded into the environment by two opcodes, `intcblock` and `bytecblock`. Both of these use [proto-buf style variable length unsigned int](https://developers.google.com/protocol-buffers/docs/encoding#varint), reproduced [here](#varuint). The `intcblock` opcode is followed by a varuint specifying the length of the array and then that number of varuint. The `bytecblock` opcode is followed by a varuint array length then that number of pairs of (varuint, bytes) length prefixed byte strings. This should efficiently load 32 and 64 byte constants which will be common as addresses, hashes, and signatures.
 
-Constants are pushed onto the stack by `intc`, `intc_[0123]`, `bytec`, and `bytec_[0123]`. The assembler will handle converting `int N` or `byte N` into the appropriate form of the instruction needed.
+Constants are pushed onto the stack by `intc`, `intc_[0123]`, `pushint`, `bytec`, `bytec_[0123]`, and `pushbytes`. The assembler will handle converting `int N` or `byte N` into the appropriate form of the instruction needed.
 
 ### Named Integer Constants
 
@@ -88,6 +88,8 @@ An application transaction must indicate the action to be taken following the ex
 ## Operations
 
 Most operations work with only one type of argument, uint64 or bytes, and panic if the wrong type value is on the stack.
+
+Many instructions accept values to designate Accounts, Assets, or Applications. Beginning with TEAL v4, these values may always be given as an _offset_ in the corresponding Txn fields (Txn.Accounts, Txn.ForeignAssets, Txn.ForeignApps) _or_ as the value itself (a bytes address for Accounts, or a uint64 id). The values, however, must still be present in the Txn fields. Before TEAL v4, most opcodes required the use of an offset, except for reading account local values of assets or applications, which accepted the IDs directly and did not require the ID to be present in they corresponding _Foreign_ array.  See individual opcodes for details. In the case of account offsets or application offsets, 0 is specially defined to Txn.Sender or the ID of the current application, respectively.
 
 Many programs need only a few dozen instructions. The instruction set has some optimization built in. `intc`, `bytec`, and `arg` take an immediate value byte, making a 2-byte op to load a value onto the stack, but they also have single byte versions for loading the most common constant values. Any program will benefit from having a few common values loaded with a smaller one byte opcode. Cryptographic hashes and `ed25519verify` are single byte opcodes with powerful libraries behind them. These operations still take more time than other ops (and this is reflected in the cost of each op and the cost limit of a program) but are efficient in compiled code space.
 
@@ -354,19 +356,19 @@ Asset fields include `AssetHolding` and `AssetParam` fields that are used in `as
 
 | Op | Description |
 | --- | --- |
-| `balance` | get balance for the requested account specified by Txn.Accounts[A] in microalgos. A is specified as an account index in the Accounts field of the ApplicationCall transaction, zero index means the sender. The balance is observed after the effects of previous transactions in the group, and after the fee for the current transaction is deducted. |
-| `min_balance` | get minimum required balance for the requested account specified by Txn.Accounts[A] in microalgos. A is specified as an account index in the Accounts field of the ApplicationCall transaction, zero index means the sender. Required balance is affected by [ASA](https://developer.algorand.org/docs/features/asa/#assets-overview) and [App](https://developer.algorand.org/docs/features/asc1/stateful/#minimum-balance-requirement-for-a-smart-contract) usage. When creating or opting into an app, the minimum balance grows before the app code runs, therefore the increase is visible there. When deleting or closing out, the minimum balance decreases after the app executes. |
-| `app_opted_in` | check if account specified by Txn.Accounts[A] opted in for the application B => {0 or 1} |
-| `app_local_get` | read from account specified by Txn.Accounts[A] from local state of the current application key B => value |
-| `app_local_get_ex` | read from account specified by Txn.Accounts[A] from local state of the application B key C => [*... stack*, value, 0 or 1] |
+| `balance` | get balance account A, in microalgos. The balance is observed after the effects of previous transactions in the group, and after the fee for the current transaction is deducted. |
+| `min_balance` | get minimum required balance account A, in microalgos. Required balance is affected by [ASA](https://developer.algorand.org/docs/features/asa/#assets-overview) and [App](https://developer.algorand.org/docs/features/asc1/stateful/#minimum-balance-requirement-for-a-smart-contract) usage. When creating or opting into an app, the minimum balance grows before the app code runs, therefore the increase is visible there. When deleting or closing out, the minimum balance decreases after the app executes. |
+| `app_opted_in` | check if account A opted in for the application B => {0 or 1} |
+| `app_local_get` | read from account A from local state of the current application key B => value |
+| `app_local_get_ex` | read from account A from local state of the application B key C => [*... stack*, value, 0 or 1] |
 | `app_global_get` | read key A from global state of a current application => value |
-| `app_global_get_ex` | read from application Txn.ForeignApps[A] global state key B => [*... stack*, value, 0 or 1]. A is specified as an account index in the ForeignApps field of the ApplicationCall transaction, zero index means this app |
-| `app_local_put` | write to account specified by Txn.Accounts[A] to local state of a current application key B with value C |
+| `app_global_get_ex` | read from application A global state key B => [*... stack*, value, 0 or 1] |
+| `app_local_put` | write to account specified by A to local state of a current application key B with value C |
 | `app_global_put` | write key A and value B to global state of the current application |
-| `app_local_del` | delete from account specified by Txn.Accounts[A] local state key B of the current application |
+| `app_local_del` | delete from account A local state key B of the current application |
 | `app_global_del` | delete key A from a global state of the current application |
-| `asset_holding_get i` | read from account specified by Txn.Accounts[A] and asset B holding field X (imm arg) => {0 or 1 (top), value} |
-| `asset_params_get i` | read from asset Txn.ForeignAssets[A] params field X (imm arg) => {0 or 1 (top), value} |
+| `asset_holding_get i` | read from account A and asset B holding field X (imm arg) => {0 or 1 (top), value} |
+| `asset_params_get i` | read from asset A params field X (imm arg) => {0 or 1 (top), value} |
 
 # Assembler Syntax
 

--- a/dev/TEAL.md
+++ b/dev/TEAL.md
@@ -35,7 +35,7 @@ A program can either authorize some delegated action on a normal private key sig
 * If the account has signed the program (an ed25519 signature on "Program" concatenated with the program bytes) then if the program returns true the transaction is authorized as if the account had signed it. This allows an account to hand out a signed program so that other users can carry out delegated actions which are approved by the program.
 * If the SHA512_256 hash of the program (prefixed by "Program") is equal to the transaction Sender address then this is a contract account wholly controlled by the program. No other signature is necessary or possible. The only way to execute a transaction against the contract account is for the program to approve it.
 
-The TEAL bytecode plus the length of any Args must add up to less than 1000 bytes (consensus parameter LogicSigMaxSize). Each TEAL op has an associated cost estimate and the program cost estimate must total less than 20000 (consensus parameter LogicSigMaxCost). Most ops have an estimated cost of 1, but a few slow crypto ops are much higher.
+The TEAL bytecode plus the length of any Args must add up to less than 1000 bytes (consensus parameter LogicSigMaxSize). Each TEAL op has an associated cost and the program cost must total less than 20000 (consensus parameter LogicSigMaxCost). Most ops have a cost of 1, but a few slow crypto ops are much higher. Prior to v4, program costs was estimated as the static sum of all opcode costs in a program (ignoring conditionals that might skip some code).  Beginning with v4, a program's cost is tracked dynamically, while being evaluated. If the program exceeds its budget, it fails.
 
 ## Execution modes
 
@@ -88,11 +88,6 @@ An application transaction must indicate the action to be taken following the ex
 ## Operations
 
 Most operations work with only one type of argument, uint64 or bytes, and panic if the wrong type value is on the stack.
-The instruction set was designed to execute calculator-like expressions.
-What might be a one line expression with various parenthesized clauses should be efficiently representable in TEAL.
-
-Looping is not possible, by design, to ensure predictably fast execution.
-There is a branch instruction (`bnz`, branch if not zero) which allows forward branching only so that some code may be skipped.
 
 Many programs need only a few dozen instructions. The instruction set has some optimization built in. `intc`, `bytec`, and `arg` take an immediate value byte, making a 2-byte op to load a value onto the stack, but they also have single byte versions for loading the most common constant values. Any program will benefit from having a few common values loaded with a smaller one byte opcode. Cryptographic hashes and `ed25519verify` are single byte opcodes with powerful libraries behind them. These operations still take more time than other ops (and this is reflected in the cost of each op and the cost limit of a program) but are efficient in compiled code space.
 
@@ -423,12 +418,12 @@ A '[proto-buf style variable length unsigned int](https://developers.google.com/
 
 # What TEAL Cannot Do
 
-Current design and implementation limitations to be aware of.
+Design and implementation limitations to be aware of with various versions of TEAL.
 
 * TEAL cannot create or change a transaction, only approve or reject.
 * Stateless TEAL cannot lookup balances of Algos or other assets. (Standard transaction accounting will apply after TEAL has run and authorized a transaction. A TEAL-approved transaction could still be invalid by other accounting rules just as a standard signed transaction could be invalid. e.g. I can't give away money I don't have.)
 * TEAL cannot access information in previous blocks. TEAL cannot access most information in other transactions in the current block. (TEAL can access fields of the transaction it is attached to and the transactions in an atomic transaction group.)
 * TEAL cannot know exactly what round the current transaction will commit in (but it is somewhere in FirstValid through LastValid).
 * TEAL cannot know exactly what time its transaction is committed.
-* TEAL cannot loop. Its branch instructions `bnz` "branch if not zero", `bz` "branch if zero" and `b` "branch" can only branch forward so as to skip some code.
-* TEAL cannot recurse. There is no subroutine jump operation.
+* TEAL cannot loop prior to v4. In v3 and prior, the branch instructions `bnz` "branch if not zero", `bz` "branch if zero" and `b` "branch" can only branch forward so as to skip some code.
+* Until v4, TEAL had no notion of subroutines (and therefore no recursion). As of v4, use `callsub` and `retsub`.

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -943,7 +943,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Opcode: 0xa0
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: []byte
-- A plus B, where A and B are byteslices interpreted as big-endian unsigned integers
+- A plus B, where A and B are byte-arrays interpreted as big-endian unsigned integers
 - LogicSigVersion >= 4
 
 ## b-
@@ -951,7 +951,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Opcode: 0xa1
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: []byte
-- A minus B, where A and B are byteslices interpreted as big-endian unsigned integers. Panic on underflow.
+- A minus B, where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic on underflow.
 - LogicSigVersion >= 4
 
 ## b/
@@ -959,7 +959,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Opcode: 0xa2
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: []byte
-- A divided by B, where A and B are byteslices interpreted as big-endian unsigned integers. Panic if B is zero.
+- A divided by B, where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic if B is zero.
 - LogicSigVersion >= 4
 
 ## b*
@@ -967,7 +967,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Opcode: 0xa3
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: []byte
-- A times B, where A and B are byteslices interpreted as big-endian unsigned integers.
+- A times B, where A and B are byte-arrays interpreted as big-endian unsigned integers.
 - LogicSigVersion >= 4
 
 ## b<
@@ -975,7 +975,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Opcode: 0xa4
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: uint64
-- A is less than B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1}
+- A is less than B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1}
 - LogicSigVersion >= 4
 
 ## b>
@@ -983,7 +983,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Opcode: 0xa5
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: uint64
-- A is greater than B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1}
+- A is greater than B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1}
 - LogicSigVersion >= 4
 
 ## b<=
@@ -991,7 +991,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Opcode: 0xa6
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: uint64
-- A is less than or equal to B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1}
+- A is less than or equal to B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1}
 - LogicSigVersion >= 4
 
 ## b>=
@@ -999,7 +999,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Opcode: 0xa7
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: uint64
-- A is greater than or equal to B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1}
+- A is greater than or equal to B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1}
 - LogicSigVersion >= 4
 
 ## b==
@@ -1007,7 +1007,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Opcode: 0xa8
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: uint64
-- A is equals to B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1}
+- A is equals to B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1}
 - LogicSigVersion >= 4
 
 ## b!=
@@ -1015,7 +1015,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Opcode: 0xa9
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: uint64
-- A is not equal to B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1}
+- A is not equal to B, where A and B are byte-arrays interpreted as big-endian unsigned integers => { 0 or 1}
 - LogicSigVersion >= 4
 
 ## b%
@@ -1023,7 +1023,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Opcode: 0xaa
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: []byte
-- A modulo B, where A and B are byteslices interpreted as big-endian unsigned integers. Panic if B is zero.
+- A modulo B, where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic if B is zero.
 - LogicSigVersion >= 4
 
 ## b|
@@ -1031,7 +1031,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Opcode: 0xab
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: []byte
-- A bitwise-or B, where A and B are byteslices interpreted as big-endian unsigned integers.
+- A bitwise-or B, where A and B are byte-arrays, zero-left extended to the greater of their lengths
 - LogicSigVersion >= 4
 
 ## b&
@@ -1039,7 +1039,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Opcode: 0xac
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: []byte
-- A bitwise-and B, where A and B are byteslices interpreted as big-endian unsigned integers.
+- A bitwise-and B, where A and B are byte-arrays, zero-left extended to the greater of their lengths
 - LogicSigVersion >= 4
 
 ## b^
@@ -1047,5 +1047,21 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Opcode: 0xad
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: []byte
-- A bitwise-xor B, where A and B are byteslices interpreted as big-endian unsigned integers.
+- A bitwise-xor B, where A and B are byte-arrays, zero-left extended to the greater of their lengths
+- LogicSigVersion >= 4
+
+## b~
+
+- Opcode: 0xae
+- Pops: *... stack*, []byte
+- Pushes: []byte
+- A with all bits inverted
+- LogicSigVersion >= 4
+
+## bzero
+
+- Opcode: 0xaf
+- Pops: *... stack*, uint64
+- Pushes: []byte
+- push a byte-array of length A, containing all zero bytes
 - LogicSigVersion >= 4

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -558,7 +558,7 @@ The `gloads` opcode can only access scratch spaces of previous app calls contain
 - Opcode: 0x3c
 - Pops: _None_
 - Pushes: uint64
-- push the ID of the asset or application created in the Tth transaction of the current group
+- push the ID of the asset or application created in the Tth transaction of the current group, or fail if nothing was created in that transaction
 - LogicSigVersion >= 4
 - Mode: Application
 
@@ -569,7 +569,7 @@ The `gaid` opcode can only access the ID of assets or applications created by pr
 - Opcode: 0x3d
 - Pops: *... stack*, uint64
 - Pushes: uint64
-- push the ID of the asset or application created in the Ath transaction of the current group
+- push the ID of the asset or application created in the Ath transaction of the current group, or fail if nothing was created in that transaction
 - LogicSigVersion >= 4
 - Mode: Application
 
@@ -577,18 +577,18 @@ The `gaids` opcode can only access the ID of assets or applications created by p
 
 ## bnz target
 
-- Opcode: 0x40 {int16 branch offset, big endian. (negative offsets are illegal before v4)}
+- Opcode: 0x40 {int16 branch offset, big endian}
 - Pops: *... stack*, uint64
 - Pushes: _None_
 - branch to TARGET if value X is not zero
 
-The `bnz` instruction opcode 0x40 is followed by two immediate data bytes which are a high byte first and low byte second which together form a 16 bit offset which the instruction may branch to. For a bnz instruction at `pc`, if the last element of the stack is not zero then branch to instruction at `pc + 3 + N`, else proceed to next instruction at `pc + 3`. Branch targets must be well aligned instructions. (e.g. Branching to the second byte of a 2 byte op will be rejected.) Branch offsets are limited to forward branches only, 0-0x7fff until v4. v4 treats offset as a signed 16 bit integer allowing for backward branches and looping.
+The `bnz` instruction opcode 0x40 is followed by two immediate data bytes which are a high byte first and low byte second which together form a 16 bit offset which the instruction may branch to. For a bnz instruction at `pc`, if the last element of the stack is not zero then branch to instruction at `pc + 3 + N`, else proceed to next instruction at `pc + 3`. Branch targets must be aligned instructions. (e.g. Branching to the second byte of a 2 byte op will be rejected.) Starting at v4, the offset is treated as a signed 16 bit integer allowing for backward branches and looping. In prior version (v1 to v3), branch offsets are limited to forward branches only, 0-0x7fff.
 
-At LogicSigVersion 2 it became allowed to branch to the end of the program exactly after the last instruction: bnz to byte N (with 0-indexing) was illegal for a TEAL program with N bytes before LogicSigVersion 2, and is legal after it. This change eliminates the need for a last instruction of no-op as a branch target at the end. (Branching beyond the end--in other words, to a byte larger than N--is still illegal and will cause the program to fail.)
+At v2 it became allowed to branch to the end of the program exactly after the last instruction: bnz to byte N (with 0-indexing) was illegal for a TEAL program with N bytes before v2, and is legal after it. This change eliminates the need for a last instruction of no-op as a branch target at the end. (Branching beyond the end--in other words, to a byte larger than N--is still illegal and will cause the program to fail.)
 
 ## bz target
 
-- Opcode: 0x41 {int16 branch offset, big endian. (negative offsets are illegal before v4)}
+- Opcode: 0x41 {int16 branch offset, big endian}
 - Pops: *... stack*, uint64
 - Pushes: _None_
 - branch to TARGET if value X is zero
@@ -598,7 +598,7 @@ See `bnz` for details on how branches work. `bz` inverts the behavior of `bnz`.
 
 ## b target
 
-- Opcode: 0x42 {int16 branch offset, big endian. (negative offsets are illegal before v4)}
+- Opcode: 0x42 {int16 branch offset, big endian}
 - Pops: _None_
 - Pushes: _None_
 - branch unconditionally to TARGET

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -433,6 +433,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 | 53 | GlobalNumByteSlice | uint64 | Number of global state byteslices in ApplicationCall. LogicSigVersion >= 3. |
 | 54 | LocalNumUint | uint64 | Number of local state integers in ApplicationCall. LogicSigVersion >= 3. |
 | 55 | LocalNumByteSlice | uint64 | Number of local state byteslices in ApplicationCall. LogicSigVersion >= 3. |
+| 56 | AppProgramExtraPages | uint64 |  |
 
 
 TypeEnum mapping:
@@ -529,6 +530,28 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 - Pushes: any
 - push Ith value of the array field F from the Ath transaction in the current group
 - LogicSigVersion >= 3
+
+## gload t i
+
+- Opcode: 0x3a {uint8 transaction group index} {uint8 position in scratch space to load from}
+- Pops: _None_
+- Pushes: any
+- push Ith scratch space index of the Tth transaction in the current group
+- LogicSigVersion >= 4
+- Mode: Application
+
+The `gload` opcode can only access scratch spaces of previous app calls contained in the current group.
+
+## gloads i
+
+- Opcode: 0x3b {uint8 position in scratch space to load from}
+- Pops: *... stack*, uint64
+- Pushes: any
+- push Ith scratch space index of the Ath transaction in the current group
+- LogicSigVersion >= 4
+- Mode: Application
+
+The `gloads` opcode can only access scratch spaces of previous app calls contained in the current group.
 
 ## bnz target
 

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -711,44 +711,46 @@ bit indexing begins with low-order bits in integers. Setting bit 4 to 1 on the i
 ## balance
 
 - Opcode: 0x60
-- Pops: *... stack*, uint64
+- Pops: *... stack*, any
 - Pushes: uint64
-- get balance for the requested account specified by Txn.Accounts[A] in microalgos. A is specified as an account index in the Accounts field of the ApplicationCall transaction, zero index means the sender. The balance is observed after the effects of previous transactions in the group, and after the fee for the current transaction is deducted.
+- get balance account A, in microalgos. The balance is observed after the effects of previous transactions in the group, and after the fee for the current transaction is deducted.
 - LogicSigVersion >= 2
 - Mode: Application
+
+params: Txn.Accounts offset (or, since v4, an account address that appears in Txn.Accounts or is Txn.Sender). Return: value.
 
 ## app_opted_in
 
 - Opcode: 0x61
-- Pops: *... stack*, {uint64 A}, {uint64 B}
+- Pops: *... stack*, {any A}, {uint64 B}
 - Pushes: uint64
-- check if account specified by Txn.Accounts[A] opted in for the application B => {0 or 1}
+- check if account A opted in for the application B => {0 or 1}
 - LogicSigVersion >= 2
 - Mode: Application
 
-params: account index, application id (top of the stack on opcode entry). Return: 1 if opted in and 0 otherwise.
+params: Txn.Accounts offset (or, since v4, an account address that appears in Txn.Accounts or is Txn.Sender), application id (or, since v4, a Txn.ForeignApps offset). Return: 1 if opted in and 0 otherwise.
 
 ## app_local_get
 
 - Opcode: 0x62
-- Pops: *... stack*, {uint64 A}, {[]byte B}
+- Pops: *... stack*, {any A}, {[]byte B}
 - Pushes: any
-- read from account specified by Txn.Accounts[A] from local state of the current application key B => value
+- read from account A from local state of the current application key B => value
 - LogicSigVersion >= 2
 - Mode: Application
 
-params: account index, state key. Return: value. The value is zero (of type uint64) if the key does not exist.
+params: Txn.Accounts offset (or, since v4, an account address that appears in Txn.Accounts or is Txn.Sender), state key. Return: value. The value is zero (of type uint64) if the key does not exist.
 
 ## app_local_get_ex
 
 - Opcode: 0x63
-- Pops: *... stack*, {uint64 A}, {uint64 B}, {[]byte C}
+- Pops: *... stack*, {any A}, {uint64 B}, {[]byte C}
 - Pushes: *... stack*, any, uint64
-- read from account specified by Txn.Accounts[A] from local state of the application B key C => [*... stack*, value, 0 or 1]
+- read from account A from local state of the application B key C => [*... stack*, value, 0 or 1]
 - LogicSigVersion >= 2
 - Mode: Application
 
-params: account index, application id, state key. Return: did_exist flag (top of the stack, 1 if exist and 0 otherwise), value. The value is zero (of type uint64) if the key does not exist.
+params: Txn.Accounts offset (or, since v4, an account address that appears in Txn.Accounts or is Txn.Sender), application id (or, since v4, a Txn.ForeignApps offset), state key. Return: did_exist flag (top of the stack, 1 if exist and 0 otherwise), value. The value is zero (of type uint64) if the key does not exist.
 
 ## app_global_get
 
@@ -766,22 +768,22 @@ params: state key. Return: value. The value is zero (of type uint64) if the key 
 - Opcode: 0x65
 - Pops: *... stack*, {uint64 A}, {[]byte B}
 - Pushes: *... stack*, any, uint64
-- read from application Txn.ForeignApps[A] global state key B => [*... stack*, value, 0 or 1]. A is specified as an account index in the ForeignApps field of the ApplicationCall transaction, zero index means this app
+- read from application A global state key B => [*... stack*, value, 0 or 1]
 - LogicSigVersion >= 2
 - Mode: Application
 
-params: application index, state key. Return: did_exist flag (top of the stack, 1 if exist and 0 otherwise), value. The value is zero (of type uint64) if the key does not exist.
+params: Txn.ForeignApps offset (or, since v4, an application id that appears in Txn.ForeignApps or is the CurrentApplicationID), state key. Return: did_exist flag (top of the stack, 1 if exist and 0 otherwise), value. The value is zero (of type uint64) if the key does not exist.
 
 ## app_local_put
 
 - Opcode: 0x66
-- Pops: *... stack*, {uint64 A}, {[]byte B}, {any C}
+- Pops: *... stack*, {any A}, {[]byte B}, {any C}
 - Pushes: _None_
-- write to account specified by Txn.Accounts[A] to local state of a current application key B with value C
+- write to account specified by A to local state of a current application key B with value C
 - LogicSigVersion >= 2
 - Mode: Application
 
-params: account index, state key, value.
+params: Txn.Accounts offset (or, since v4, an account address that appears in Txn.Accounts or is Txn.Sender), state key, value.
 
 ## app_global_put
 
@@ -795,13 +797,13 @@ params: account index, state key, value.
 ## app_local_del
 
 - Opcode: 0x68
-- Pops: *... stack*, {uint64 A}, {[]byte B}
+- Pops: *... stack*, {any A}, {[]byte B}
 - Pushes: _None_
-- delete from account specified by Txn.Accounts[A] local state key B of the current application
+- delete from account A local state key B of the current application
 - LogicSigVersion >= 2
 - Mode: Application
 
-params: account index, state key.
+params: Txn.Accounts offset (or, since v4, an account address that appears in Txn.Accounts or is Txn.Sender), state key.
 
 Deleting a key which is already absent has no effect on the application local state. (In particular, it does _not_ cause the program to fail.)
 
@@ -821,9 +823,9 @@ Deleting a key which is already absent has no effect on the application global s
 ## asset_holding_get i
 
 - Opcode: 0x70 {uint8 asset holding field index}
-- Pops: *... stack*, {uint64 A}, {uint64 B}
+- Pops: *... stack*, {any A}, {uint64 B}
 - Pushes: *... stack*, any, uint64
-- read from account specified by Txn.Accounts[A] and asset B holding field X (imm arg) => {0 or 1 (top), value}
+- read from account A and asset B holding field X (imm arg) => {0 or 1 (top), value}
 - LogicSigVersion >= 2
 - Mode: Application
 
@@ -835,14 +837,14 @@ Deleting a key which is already absent has no effect on the application global s
 | 1 | AssetFrozen | uint64 | Is the asset frozen or not |
 
 
-params: account index, asset id. Return: did_exist flag (1 if exist and 0 otherwise), value.
+params: Txn.Accounts offset (or, since v4, an account address that appears in Txn.Accounts or is Txn.Sender), asset id (or, since v4, a Txn.ForeignAssets offset). Return: did_exist flag (1 if exist and 0 otherwise), value.
 
 ## asset_params_get i
 
 - Opcode: 0x71 {uint8 asset params field index}
 - Pops: *... stack*, uint64
 - Pushes: *... stack*, any, uint64
-- read from asset Txn.ForeignAssets[A] params field X (imm arg) => {0 or 1 (top), value}
+- read from asset A params field X (imm arg) => {0 or 1 (top), value}
 - LogicSigVersion >= 2
 - Mode: Application
 
@@ -863,16 +865,18 @@ params: account index, asset id. Return: did_exist flag (1 if exist and 0 otherw
 | 10 | AssetClawback | []byte | Clawback address |
 
 
-params: txn.ForeignAssets offset. Return: did_exist flag (1 if exist and 0 otherwise), value.
+params: Txn.ForeignAssets offset (or, since v4, an asset id that appears in Txn.ForeignAssets). Return: did_exist flag (1 if exist and 0 otherwise), value.
 
 ## min_balance
 
 - Opcode: 0x78
-- Pops: *... stack*, uint64
+- Pops: *... stack*, any
 - Pushes: uint64
-- get minimum required balance for the requested account specified by Txn.Accounts[A] in microalgos. A is specified as an account index in the Accounts field of the ApplicationCall transaction, zero index means the sender. Required balance is affected by [ASA](https://developer.algorand.org/docs/features/asa/#assets-overview) and [App](https://developer.algorand.org/docs/features/asc1/stateful/#minimum-balance-requirement-for-a-smart-contract) usage. When creating or opting into an app, the minimum balance grows before the app code runs, therefore the increase is visible there. When deleting or closing out, the minimum balance decreases after the app executes.
+- get minimum required balance account A, in microalgos. Required balance is affected by [ASA](https://developer.algorand.org/docs/features/asa/#assets-overview) and [App](https://developer.algorand.org/docs/features/asc1/stateful/#minimum-balance-requirement-for-a-smart-contract) usage. When creating or opting into an app, the minimum balance grows before the app code runs, therefore the increase is visible there. When deleting or closing out, the minimum balance decreases after the app executes.
 - LogicSigVersion >= 3
 - Mode: Application
+
+params: Txn.Accounts offset (or, since v4, an account address that appears in Txn.Accounts or is Txn.Sender). Return: value.
 
 ## pushbytes bytes
 

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -739,7 +739,7 @@ When A is a uint64, index 0 is the least significant bit. Setting bit 3 to 1 on 
 - LogicSigVersion >= 2
 - Mode: Application
 
-params: Txn.Accounts offset (or, since v4, an account address that appears in Txn.Accounts or is Txn.Sender). Return: value.
+params: Before v4, Txn.Accounts offset. Since v4, Txn.Accounts offset or an account address that appears in Txn.Accounts or is Txn.Sender). Return: value.
 
 ## app_opted_in
 
@@ -887,7 +887,7 @@ params: Txn.Accounts offset (or, since v4, an account address that appears in Tx
 | 10 | AssetClawback | []byte | Clawback address |
 
 
-params: Txn.ForeignAssets offset (or, since v4, an asset id that appears in Txn.ForeignAssets). Return: did_exist flag (1 if exist and 0 otherwise), value.
+params: Before v4, Txn.ForeignAssets offset. Since v4, Txn.ForeignAssets offset or an asset id that appears in Txn.ForeignAssets. Return: did_exist flag (1 if exist and 0 otherwise), value.
 
 ## min_balance
 
@@ -898,7 +898,7 @@ params: Txn.ForeignAssets offset (or, since v4, an asset id that appears in Txn.
 - LogicSigVersion >= 3
 - Mode: Application
 
-params: Txn.Accounts offset (or, since v4, an account address that appears in Txn.Accounts or is Txn.Sender). Return: value.
+params: Before v4, Txn.Accounts offset. Since v4, Txn.Accounts offset or an account address that appears in Txn.Accounts or is Txn.Sender). Return: value.
 
 ## pushbytes bytes
 

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -26,8 +26,7 @@ Ops have a 'cost' of 1 unless otherwise specified.
 - SHA256 hash of value X, yields [32]byte
 - **Cost**:
    - 7 (LogicSigVersion = 1)
-   - 35 (LogicSigVersion = 2)
-   - 35 (LogicSigVersion = 3)
+   - 35 (2 <= LogicSigVersion <= 3)
 
 ## keccak256
 
@@ -37,8 +36,7 @@ Ops have a 'cost' of 1 unless otherwise specified.
 - Keccak256 hash of value X, yields [32]byte
 - **Cost**:
    - 26 (LogicSigVersion = 1)
-   - 130 (LogicSigVersion = 2)
-   - 130 (LogicSigVersion = 3)
+   - 130 (2 <= LogicSigVersion <= 3)
 
 ## sha512_256
 
@@ -48,8 +46,7 @@ Ops have a 'cost' of 1 unless otherwise specified.
 - SHA512_256 hash of value X, yields [32]byte
 - **Cost**:
    - 9 (LogicSigVersion = 1)
-   - 45 (LogicSigVersion = 2)
-   - 45 (LogicSigVersion = 3)
+   - 45 (2 <= LogicSigVersion <= 3)
 
 ## ed25519verify
 

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -26,7 +26,7 @@ Ops have a 'cost' of 1 unless otherwise specified.
 - SHA256 hash of value X, yields [32]byte
 - **Cost**:
    - 7 (LogicSigVersion = 1)
-   - 35 (2 <= LogicSigVersion <= 3)
+   - 35 (2 <= LogicSigVersion <= 4)
 
 ## keccak256
 
@@ -36,7 +36,7 @@ Ops have a 'cost' of 1 unless otherwise specified.
 - Keccak256 hash of value X, yields [32]byte
 - **Cost**:
    - 26 (LogicSigVersion = 1)
-   - 130 (2 <= LogicSigVersion <= 3)
+   - 130 (2 <= LogicSigVersion <= 4)
 
 ## sha512_256
 
@@ -46,7 +46,7 @@ Ops have a 'cost' of 1 unless otherwise specified.
 - SHA512_256 hash of value X, yields [32]byte
 - **Cost**:
    - 9 (LogicSigVersion = 1)
-   - 45 (2 <= LogicSigVersion <= 3)
+   - 45 (2 <= LogicSigVersion <= 4)
 
 ## ed25519verify
 
@@ -81,6 +81,8 @@ Overflow is an error condition which halts execution and fails the transaction. 
 - Pops: *... stack*, {uint64 A}, {uint64 B}
 - Pushes: uint64
 - A divided by B. Panic if B == 0.
+
+`divmodw` is available to divide the two-element values produced by `mulw` and `addw`.
 
 ## *
 
@@ -226,6 +228,14 @@ Overflow is an error condition which halts execution and fails the transaction. 
 - Pushes: *... stack*, uint64, uint64
 - A plus B out to 128-bit long result as sum (top) and carry-bit uint64 values on the stack
 - LogicSigVersion >= 2
+
+## divmodw
+
+- Opcode: 0x1f
+- Pops: *... stack*, {uint64 A}, {uint64 B}, {uint64 C}, {uint64 D}
+- Pushes: *... stack*, uint64, uint64, uint64, uint64
+- Pop four uint64 values.  The deepest two are interpreted as a uint128 dividend (deepest value is high word), the top two are interpreted as a uint128 divisor.  Four uint64 values are pushed to the stack. The deepest two are the quotient (deeper value is the high uint64). The top two are the remainder, low bits on top.
+- LogicSigVersion >= 4
 
 ## intcblock uint ...
 
@@ -521,18 +531,18 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 
 ## bnz target
 
-- Opcode: 0x40 {0..0x7fff forward branch offset, big endian}
+- Opcode: 0x40 {int16 branch offset, big endian. (negative offsets are illegal before v4)}
 - Pops: *... stack*, uint64
 - Pushes: _None_
 - branch to TARGET if value X is not zero
 
-The `bnz` instruction opcode 0x40 is followed by two immediate data bytes which are a high byte first and low byte second which together form a 16 bit offset which the instruction may branch to. For a bnz instruction at `pc`, if the last element of the stack is not zero then branch to instruction at `pc + 3 + N`, else proceed to next instruction at `pc + 3`. Branch targets must be well aligned instructions. (e.g. Branching to the second byte of a 2 byte op will be rejected.) Branch offsets are currently limited to forward branches only, 0-0x7fff. A future expansion might make this a signed 16 bit integer allowing for backward branches and looping.
+The `bnz` instruction opcode 0x40 is followed by two immediate data bytes which are a high byte first and low byte second which together form a 16 bit offset which the instruction may branch to. For a bnz instruction at `pc`, if the last element of the stack is not zero then branch to instruction at `pc + 3 + N`, else proceed to next instruction at `pc + 3`. Branch targets must be well aligned instructions. (e.g. Branching to the second byte of a 2 byte op will be rejected.) Branch offsets are limited to forward branches only, 0-0x7fff until v4. v4 treats offset as a signed 16 bit integer allowing for backward branches and looping.
 
 At LogicSigVersion 2 it became allowed to branch to the end of the program exactly after the last instruction: bnz to byte N (with 0-indexing) was illegal for a TEAL program with N bytes before LogicSigVersion 2, and is legal after it. This change eliminates the need for a last instruction of no-op as a branch target at the end. (Branching beyond the end--in other words, to a byte larger than N--is still illegal and will cause the program to fail.)
 
 ## bz target
 
-- Opcode: 0x41 {0..0x7fff forward branch offset, big endian}
+- Opcode: 0x41 {int16 branch offset, big endian. (negative offsets are illegal before v4)}
 - Pops: *... stack*, uint64
 - Pushes: _None_
 - branch to TARGET if value X is zero
@@ -542,7 +552,7 @@ See `bnz` for details on how branches work. `bz` inverts the behavior of `bnz`.
 
 ## b target
 
-- Opcode: 0x42 {0..0x7fff forward branch offset, big endian}
+- Opcode: 0x42 {int16 branch offset, big endian. (negative offsets are illegal before v4)}
 - Pops: _None_
 - Pushes: _None_
 - branch unconditionally to TARGET
@@ -652,7 +662,7 @@ see explanation of bit ordering in setbit
 
 - Opcode: 0x54
 - Pops: *... stack*, {any A}, {uint64 B}, {uint64 C}
-- Pushes: uint64
+- Pushes: any
 - pop a target A, index B, and bit C. Set the Bth bit of A to C, and push the result
 - LogicSigVersion >= 3
 
@@ -848,6 +858,8 @@ params: txn.ForeignAssets offset. Return: did_exist flag (1 if exist and 0 other
 - push the following program bytes to the stack
 - LogicSigVersion >= 3
 
+pushbytes args are not added to the bytecblock during assembly processes
+
 ## pushint uint
 
 - Opcode: 0x81 {varuint int}
@@ -855,3 +867,181 @@ params: txn.ForeignAssets offset. Return: did_exist flag (1 if exist and 0 other
 - Pushes: uint64
 - push immediate UINT to the stack as an integer
 - LogicSigVersion >= 3
+
+pushint args are not added to the intcblock during assembly processes
+
+## callsub target
+
+- Opcode: 0x88
+- Pops: _None_
+- Pushes: _None_
+- branch unconditionally to TARGET, saving the next instruction on the call stack
+- LogicSigVersion >= 4
+
+## retsub
+
+- Opcode: 0x89
+- Pops: _None_
+- Pushes: _None_
+- pop the top instruction from the call stack and branch to it
+- LogicSigVersion >= 4
+
+## shl
+
+- Opcode: 0x90
+- Pops: *... stack*, {uint64 A}, {uint64 B}
+- Pushes: uint64
+- A times 2^B, modulo 2^64
+- LogicSigVersion >= 4
+
+## shr
+
+- Opcode: 0x91
+- Pops: *... stack*, {uint64 A}, {uint64 B}
+- Pushes: uint64
+- A divided by 2^B
+- LogicSigVersion >= 4
+
+## sqrt
+
+- Opcode: 0x92
+- Pops: *... stack*, uint64
+- Pushes: uint64
+- The largest integer X such that X^2 <= A
+- LogicSigVersion >= 4
+
+## log2
+
+- Opcode: 0x93
+- Pops: *... stack*, uint64
+- Pushes: uint64
+- The largest integer X such that 2^X <= A
+- LogicSigVersion >= 4
+
+## exp
+
+- Opcode: 0x94
+- Pops: *... stack*, {uint64 A}, {uint64 B}
+- Pushes: uint64
+- A raised to the Bth power. Panic if A == B == 0 and on overflow
+- LogicSigVersion >= 4
+
+## expw
+
+- Opcode: 0x95
+- Pops: *... stack*, {uint64 A}, {uint64 B}
+- Pushes: *... stack*, uint64, uint64
+- A raised to the Bth power as a 128-bit long result as low (top) and high uint64 values on the stack. Panic if A == B == 0 or if the results exceeds 2^128-1
+- LogicSigVersion >= 4
+
+## b+
+
+- Opcode: 0xa0
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: []byte
+- A plus B, where A and B are byteslices interpreted as big-endian unsigned integers
+- LogicSigVersion >= 4
+
+## b-
+
+- Opcode: 0xa1
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: []byte
+- A minus B, where A and B are byteslices interpreted as big-endian unsigned integers. Panic on underflow.
+- LogicSigVersion >= 4
+
+## b/
+
+- Opcode: 0xa2
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: []byte
+- A divided by B, where A and B are byteslices interpreted as big-endian unsigned integers. Panic if B is zero.
+- LogicSigVersion >= 4
+
+## b*
+
+- Opcode: 0xa3
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: []byte
+- A times B, where A and B are byteslices interpreted as big-endian unsigned integers.
+- LogicSigVersion >= 4
+
+## b<
+
+- Opcode: 0xa4
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: uint64
+- A is less than B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1}
+- LogicSigVersion >= 4
+
+## b>
+
+- Opcode: 0xa5
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: uint64
+- A is greater than B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1}
+- LogicSigVersion >= 4
+
+## b<=
+
+- Opcode: 0xa6
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: uint64
+- A is less than or equal to B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1}
+- LogicSigVersion >= 4
+
+## b>=
+
+- Opcode: 0xa7
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: uint64
+- A is greater than or equal to B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1}
+- LogicSigVersion >= 4
+
+## b==
+
+- Opcode: 0xa8
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: uint64
+- A is equals to B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1}
+- LogicSigVersion >= 4
+
+## b!=
+
+- Opcode: 0xa9
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: uint64
+- A is not equal to B, where A and B are byteslices interpreted as big-endian unsigned integers => { 0 or 1}
+- LogicSigVersion >= 4
+
+## b%
+
+- Opcode: 0xaa
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: []byte
+- A modulo B, where A and B are byteslices interpreted as big-endian unsigned integers. Panic if B is zero.
+- LogicSigVersion >= 4
+
+## b|
+
+- Opcode: 0xab
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: []byte
+- A bitwise-or B, where A and B are byteslices interpreted as big-endian unsigned integers.
+- LogicSigVersion >= 4
+
+## b&
+
+- Opcode: 0xac
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: []byte
+- A bitwise-and B, where A and B are byteslices interpreted as big-endian unsigned integers.
+- LogicSigVersion >= 4
+
+## b^
+
+- Opcode: 0xad
+- Pops: *... stack*, {[]byte A}, {[]byte B}
+- Pushes: []byte
+- A bitwise-xor B, where A and B are byteslices interpreted as big-endian unsigned integers.
+- LogicSigVersion >= 4

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -735,7 +735,7 @@ When A is a uint64, index 0 is the least significant bit. Setting bit 3 to 1 on 
 - Opcode: 0x60
 - Pops: *... stack*, any
 - Pushes: uint64
-- get balance account A, in microalgos. The balance is observed after the effects of previous transactions in the group, and after the fee for the current transaction is deducted.
+- get balance for account A, in microalgos. The balance is observed after the effects of previous transactions in the group, and after the fee for the current transaction is deducted.
 - LogicSigVersion >= 2
 - Mode: Application
 
@@ -894,7 +894,7 @@ params: Txn.ForeignAssets offset (or, since v4, an asset id that appears in Txn.
 - Opcode: 0x78
 - Pops: *... stack*, any
 - Pushes: uint64
-- get minimum required balance account A, in microalgos. Required balance is affected by [ASA](https://developer.algorand.org/docs/features/asa/#assets-overview) and [App](https://developer.algorand.org/docs/features/asc1/stateful/#minimum-balance-requirement-for-a-smart-contract) usage. When creating or opting into an app, the minimum balance grows before the app code runs, therefore the increase is visible there. When deleting or closing out, the minimum balance decreases after the app executes.
+- get minimum required balance for account A, in microalgos. Required balance is affected by [ASA](https://developer.algorand.org/docs/features/asa/#assets-overview) and [App](https://developer.algorand.org/docs/features/asc1/stateful/#minimum-balance-requirement-for-a-smart-contract) usage. When creating or opting into an app, the minimum balance grows before the app code runs, therefore the increase is visible there. When deleting or closing out, the minimum balance decreases after the app executes.
 - LogicSigVersion >= 3
 - Mode: Application
 

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -433,7 +433,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 | 53 | GlobalNumByteSlice | uint64 | Number of global state byteslices in ApplicationCall. LogicSigVersion >= 3. |
 | 54 | LocalNumUint | uint64 | Number of local state integers in ApplicationCall. LogicSigVersion >= 3. |
 | 55 | LocalNumByteSlice | uint64 | Number of local state byteslices in ApplicationCall. LogicSigVersion >= 3. |
-| 56 | AppProgramExtraPages | uint64 |  |
+| 56 | ExtraProgramPages | uint64 | Number of additional pages for each of the application's approval and clear state programs. An ExtraProgramPages of 1 means 2048 more total bytes, or 1024 for each program. LogicSigVersion >= 4. |
 
 
 TypeEnum mapping:
@@ -552,6 +552,28 @@ The `gload` opcode can only access scratch spaces of previous app calls containe
 - Mode: Application
 
 The `gloads` opcode can only access scratch spaces of previous app calls contained in the current group.
+
+## gaid t
+
+- Opcode: 0x3c
+- Pops: _None_
+- Pushes: uint64
+- push the ID of the asset or application created in the Tth transaction of the current group
+- LogicSigVersion >= 4
+- Mode: Application
+
+The `gaid` opcode can only access the ID of assets or applications created by previous txns in the current group.
+
+## gaids
+
+- Opcode: 0x3d
+- Pops: *... stack*, uint64
+- Pushes: uint64
+- push the ID of the asset or application created in the Ath transaction of the current group
+- LogicSigVersion >= 4
+- Mode: Application
+
+The `gaids` opcode can only access the ID of assets or applications created by previous txns in the current group.
 
 ## bnz target
 

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -878,6 +878,8 @@ pushint args are not added to the intcblock during assembly processes
 - branch unconditionally to TARGET, saving the next instruction on the call stack
 - LogicSigVersion >= 4
 
+The call stack is separate from the data stack. Only `callsub` and `retsub` manipulate it.`
+
 ## retsub
 
 - Opcode: 0x89
@@ -885,6 +887,8 @@ pushint args are not added to the intcblock during assembly processes
 - Pushes: _None_
 - pop the top instruction from the call stack and branch to it
 - LogicSigVersion >= 4
+
+The call stack is separate from the data stack. Only `callsub` and `retsub` manipulate it.`
 
 ## shl
 

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -235,6 +235,7 @@ Overflow is an error condition which halts execution and fails the transaction. 
 - Pops: *... stack*, {uint64 A}, {uint64 B}, {uint64 C}, {uint64 D}
 - Pushes: *... stack*, uint64, uint64, uint64, uint64
 - Pop four uint64 values.  The deepest two are interpreted as a uint128 dividend (deepest value is high word), the top two are interpreted as a uint128 divisor.  Four uint64 values are pushed to the stack. The deepest two are the quotient (deeper value is the high uint64). The top two are the remainder, low bits on top.
+- **Cost**: 20
 - LogicSigVersion >= 4
 
 ## intcblock uint ...
@@ -912,15 +913,18 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Pops: *... stack*, uint64
 - Pushes: uint64
 - The largest integer X such that X^2 <= A
+- **Cost**: 4
 - LogicSigVersion >= 4
 
-## log2
+## bitlen
 
 - Opcode: 0x93
-- Pops: *... stack*, uint64
+- Pops: *... stack*, any
 - Pushes: uint64
-- The largest integer X such that 2^X <= A
+- The index of the highest bit in A. If A is a byte-array, it is interpreted as a big-endian unsigned integer
 - LogicSigVersion >= 4
+
+bitlen interprets arrays as big-endian integers, unlike setbit/getbit
 
 ## exp
 
@@ -936,6 +940,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Pops: *... stack*, {uint64 A}, {uint64 B}
 - Pushes: *... stack*, uint64, uint64
 - A raised to the Bth power as a 128-bit long result as low (top) and high uint64 values on the stack. Panic if A == B == 0 or if the results exceeds 2^128-1
+- **Cost**: 10
 - LogicSigVersion >= 4
 
 ## b+
@@ -944,6 +949,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: []byte
 - A plus B, where A and B are byte-arrays interpreted as big-endian unsigned integers
+- **Cost**: 10
 - LogicSigVersion >= 4
 
 ## b-
@@ -952,6 +958,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: []byte
 - A minus B, where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic on underflow.
+- **Cost**: 10
 - LogicSigVersion >= 4
 
 ## b/
@@ -960,6 +967,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: []byte
 - A divided by B, where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic if B is zero.
+- **Cost**: 20
 - LogicSigVersion >= 4
 
 ## b*
@@ -968,6 +976,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: []byte
 - A times B, where A and B are byte-arrays interpreted as big-endian unsigned integers.
+- **Cost**: 20
 - LogicSigVersion >= 4
 
 ## b<
@@ -1024,6 +1033,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: []byte
 - A modulo B, where A and B are byte-arrays interpreted as big-endian unsigned integers. Panic if B is zero.
+- **Cost**: 20
 - LogicSigVersion >= 4
 
 ## b|
@@ -1032,6 +1042,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: []byte
 - A bitwise-or B, where A and B are byte-arrays, zero-left extended to the greater of their lengths
+- **Cost**: 6
 - LogicSigVersion >= 4
 
 ## b&
@@ -1040,6 +1051,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: []byte
 - A bitwise-and B, where A and B are byte-arrays, zero-left extended to the greater of their lengths
+- **Cost**: 6
 - LogicSigVersion >= 4
 
 ## b^
@@ -1048,6 +1060,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Pops: *... stack*, {[]byte A}, {[]byte B}
 - Pushes: []byte
 - A bitwise-xor B, where A and B are byte-arrays, zero-left extended to the greater of their lengths
+- **Cost**: 6
 - LogicSigVersion >= 4
 
 ## b~
@@ -1056,6 +1069,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Pops: *... stack*, []byte
 - Pushes: []byte
 - A with all bits inverted
+- **Cost**: 4
 - LogicSigVersion >= 4
 
 ## bzero

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -712,7 +712,7 @@ see explanation of bit ordering in setbit
 - pop a target A, index B, and bit C. Set the Bth bit of A to C, and push the result
 - LogicSigVersion >= 3
 
-bit indexing begins with low-order bits in integers. Setting bit 4 to 1 on the integer 0 yields 16 (`int 0x0010`, or 2^4). Indexing begins in the first bytes of a byte-string (as seen in getbyte and substring). Setting bits 0 through 11 to 1 in a 4 byte-array of 0s yields `byte 0xfff00000`
+When A is a uint64, index 0 is the least significant bit. Setting bit 3 to 1 on the integer 0 yields 8, or 2^3. When A is a byte array, index 0 is the leftmost bit of the leftmost byte. Setting bits 0 through 11 to 1 in a 4-byte-array of 0s yields the byte array 0xfff00000. Setting bit 3 to 1 on the 1-byte-array 0x00 yields the byte array 0x10.
 
 ## getbyte
 
@@ -928,7 +928,7 @@ pushint args are not added to the intcblock during assembly processes
 - branch unconditionally to TARGET, saving the next instruction on the call stack
 - LogicSigVersion >= 4
 
-The call stack is separate from the data stack. Only `callsub` and `retsub` manipulate it.
+The call stack is separate from the data stack. Only `callsub` and `retsub` manipulate it.`
 
 ## retsub
 
@@ -938,7 +938,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - pop the top instruction from the call stack and branch to it
 - LogicSigVersion >= 4
 
-The call stack is separate from the data stack. Only `callsub` and `retsub` manipulate it.
+The call stack is separate from the data stack. Only `callsub` and `retsub` manipulate it.`
 
 ## shl
 
@@ -961,7 +961,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Opcode: 0x92
 - Pops: *... stack*, uint64
 - Pushes: uint64
-- The largest integer X such that X^2 <= A
+- The largest integer B such that B^2 <= X
 - **Cost**: 4
 - LogicSigVersion >= 4
 
@@ -970,7 +970,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - Opcode: 0x93
 - Pops: *... stack*, any
 - Pushes: uint64
-- The index of the highest bit in A. If A is a byte-array, it is interpreted as a big-endian unsigned integer
+- The highest set bit in X. If X is a byte-array, it is interpreted as a big-endian unsigned integer. bitlen of 0 is 0, bitlen of 8 is 4
 - LogicSigVersion >= 4
 
 bitlen interprets arrays as big-endian integers, unlike setbit/getbit
@@ -1117,7 +1117,7 @@ bitlen interprets arrays as big-endian integers, unlike setbit/getbit
 - Opcode: 0xae
 - Pops: *... stack*, []byte
 - Pushes: []byte
-- A with all bits inverted
+- X with all bits inverted
 - **Cost**: 4
 - LogicSigVersion >= 4
 
@@ -1126,5 +1126,5 @@ bitlen interprets arrays as big-endian integers, unlike setbit/getbit
 - Opcode: 0xaf
 - Pops: *... stack*, uint64
 - Pushes: []byte
-- push a byte-array of length A, containing all zero bytes
+- push a byte-array of length X, containing all zero bytes
 - LogicSigVersion >= 4

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -928,7 +928,7 @@ pushint args are not added to the intcblock during assembly processes
 - branch unconditionally to TARGET, saving the next instruction on the call stack
 - LogicSigVersion >= 4
 
-The call stack is separate from the data stack. Only `callsub` and `retsub` manipulate it.`
+The call stack is separate from the data stack. Only `callsub` and `retsub` manipulate it.
 
 ## retsub
 
@@ -938,7 +938,7 @@ The call stack is separate from the data stack. Only `callsub` and `retsub` mani
 - pop the top instruction from the call stack and branch to it
 - LogicSigVersion >= 4
 
-The call stack is separate from the data stack. Only `callsub` and `retsub` manipulate it.`
+The call stack is separate from the data stack. Only `callsub` and `retsub` manipulate it.
 
 ## shl
 

--- a/dev/TEAL_opcodes.md
+++ b/dev/TEAL_opcodes.md
@@ -518,7 +518,7 @@ for notes on transaction fields available, see `txn`. If this transaction is _i_
 - Opcode: 0x38 {uint8 transaction field index}
 - Pops: *... stack*, uint64
 - Pushes: any
-- push field F of the Ath transaction in the current group
+- push field F of the Xth transaction in the current group
 - LogicSigVersion >= 3
 
 for notes on transaction fields available, see `txn`. If top of stack is _i_, `gtxns field` is equivalent to `gtxn _i_ field`. gtxns exists so that _i_ can be calculated, often based on the index of the current transaction.
@@ -528,7 +528,7 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 - Opcode: 0x39 {uint8 transaction field index} {uint8 transaction field array index}
 - Pops: *... stack*, uint64
 - Pushes: any
-- push Ith value of the array field F from the Ath transaction in the current group
+- push Ith value of the array field F from the Xth transaction in the current group
 - LogicSigVersion >= 3
 
 ## gload t i
@@ -540,40 +540,40 @@ for notes on transaction fields available, see `txn`. If top of stack is _i_, `g
 - LogicSigVersion >= 4
 - Mode: Application
 
-The `gload` opcode can only access scratch spaces of previous app calls contained in the current group.
+`gload` fails unless the requested transaction is an ApplicationCall and T < GroupIndex.
 
 ## gloads i
 
 - Opcode: 0x3b {uint8 position in scratch space to load from}
 - Pops: *... stack*, uint64
 - Pushes: any
-- push Ith scratch space index of the Ath transaction in the current group
+- push Ith scratch space index of the Xth transaction in the current group
 - LogicSigVersion >= 4
 - Mode: Application
 
-The `gloads` opcode can only access scratch spaces of previous app calls contained in the current group.
+`gloads` fails unless the requested transaction is an ApplicationCall and X < GroupIndex.
 
 ## gaid t
 
 - Opcode: 0x3c
 - Pops: _None_
 - Pushes: uint64
-- push the ID of the asset or application created in the Tth transaction of the current group, or fail if nothing was created in that transaction
+- push the ID of the asset or application created in the Tth transaction of the current group
 - LogicSigVersion >= 4
 - Mode: Application
 
-The `gaid` opcode can only access the ID of assets or applications created by previous txns in the current group.
+`gaid` fails unless the requested transaction created an asset or application and T < GroupIndex.
 
 ## gaids
 
 - Opcode: 0x3d
 - Pops: *... stack*, uint64
 - Pushes: uint64
-- push the ID of the asset or application created in the Ath transaction of the current group, or fail if nothing was created in that transaction
+- push the ID of the asset or application created in the Xth transaction of the current group
 - LogicSigVersion >= 4
 - Mode: Application
 
-The `gaids` opcode can only access the ID of assets or applications created by previous txns in the current group.
+`gaidx` fails unless the requested transaction created an asset or application and X < GroupIndex.
 
 ## bnz target
 

--- a/dev/ledger.md
+++ b/dev/ledger.md
@@ -1057,14 +1057,20 @@ point must be discarded and the entire transaction rejected.
   `ForeignAssets` transaction field. An attempt to read asset parameters for
   an asset that is not listed in `ForeignAssets` will cause the program
   execution to fail.
-- Local state may be read for any opted-in application present in the sender’s
-  account data, or in the account data for any address listed in the
-  transaction’s `Accounts` field. An attempt to read local state from any other
-  account will cause program execution to fail.
-- Algo balances and asset balances may be read for the sender's account or for
-  any account referenced by an address listed in the transaction's `Accounts`
-  field. An attempt to read an Algo balance or asset balance for any other
-  account will cause program execution to fail.
+- Local state may be read for any opted-in application present in the
+  sender’s account data, or in the account data for any address listed
+  in the transaction’s `Accounts` field. An attempt to read local
+  state from any other tea account will cause program execution to
+  fail. Further, in TEAL programs version 4 or later, Local state
+  reads are restricted by application ID in the same way as Global
+  state reads.
+- Algo balances and asset balances may be read for the sender's
+  account or for any account referenced by an address listed in the
+  transaction's `Accounts` field. An attempt to read an Algo balance
+  or asset balance for any other account will cause program execution
+  to fail.  Further, in TEAL programs version 4 or later, asset
+  balances may only be read for assets whose parameters are also
+  readable.
 
 ## Validity and State Changes
 

--- a/dev/ledger.md
+++ b/dev/ledger.md
@@ -325,8 +325,8 @@ parameters_, which can be encoded as a msgpack struct:
   global state associated with this application. This field is encoded with
   msgpack field `approv`.
 
-  This field must not exceed 1024 bytes. The cost of the program as determined
-  by the Stateful TEAL `Check` function must not exceed 700.
+  This field must not exceed 1024*(1+`ExtraProgramPages`) bytes. The
+  cost of the program during execution must not exceed 700.
 
 - A mutable Stateful TEAL "Clear State" program (`ClearStateProgram`), executed
   when an opted-in user forcibly removes the local application state associated
@@ -337,8 +337,8 @@ parameters_, which can be encoded as a msgpack struct:
   global state associated with this application. This field is encoded with
   msgpack field `clearp`.
 
-  This field must not exceed 1024 bytes. The cost of the program as determined
-  by the Stateful TEAL `Check` function must not exceed 700.
+  This field must not exceed 1024*(1+`ExtraProgramPages`) bytes. The
+  cost of the program as during execution must not exceed 700.
 
 - An immutable "global state schema" (`GlobalStateSchema`), which sets a limit
   on the size of the global [TEAL Key/Value Store][TEAL Key/Value Stores] that
@@ -564,23 +564,23 @@ A payment transaction additionally has the following fields:
 
 A key registration transaction additionally has the following fields:
 
- - The _vote public key_ $\vpk$, (root) public authentication key 
+ - The _vote public key_ $\vpk$, (root) public authentication key
    of an account's participation keys ($\pk$).
 
- - The _selection public key_ $\spk$, public authorization key of 
-   an account's participation keys ($\pk$). If either $\vpk$ or 
-   $\spk$ is unset, the transaction deregisters the account's participation 
+ - The _selection public key_ $\spk$, public authorization key of
+   an account's participation keys ($\pk$). If either $\vpk$ or
+   $\spk$ is unset, the transaction deregisters the account's participation
    key set, as the result, marks the account offline.
 
- - The _vote first_ $\vf$, first valid round (inclusive) of 
+ - The _vote first_ $\vf$, first valid round (inclusive) of
    an account's participation key sets.
 
  - The _vote last_ $\vl$, last valid round (inclusive) of an account's
    participation key sets.
 
- - The _vote key dilution_ $\vkd$, number of rounds that a single 
-  leaf level authentication key can be used. The higher the number, the 
-  more ``dilution'' added to the authentication key's security.  
+ - The _vote key dilution_ $\vkd$, number of rounds that a single
+  leaf level authentication key can be used. The higher the number, the
+  more ``dilution'' added to the authentication key's security.
 
  - An optional (boolean) flag $\nonpart$ which, when deregistering keys,
    specifies whether to mark the account offline (if $\nonpart$ is false)
@@ -631,6 +631,9 @@ An application call transaction additionally has the following fields:
 - Global state schema, encoded as msgpack field `apgs`. This field is only used
   during application creation, and sets bounds on the size of the global state
   associated with this application.
+- Extra program pages, encoded as msgpack field `apep`. This field is only used
+  during application creation, and requests an increased maximum size for the
+  approval and clear state programs.
 - Approval program, encoded as msgpack field `apap`. This field is used for both
   application creation and updates, and sets the corresponding application's
   `ApprovalProgram`.
@@ -731,7 +734,7 @@ and contains the following fields:
 
 - The closing amount, $\ClosingAmount$, which specifies how many microalgos
   were transferred to the closing address.
- 
+
 - The asset closing amount, $\AssetClosingAmount$, which specifies how many
    of the asset units were transsfered to the closing address.
 
@@ -967,7 +970,7 @@ point must be discarded and the entire transaction rejected.
 
         When creating an application, the application parameters specified by
         the transaction (`ApprovalProgram`, `ClearStateProgram`,
-        `GlobalStateSchema`, and `LocalStateSchema`) are allocated into the
+        `GlobalStateSchema`, `LocalStateSchema`, and `ExtraProgramPages`) are allocated into the
         sender’s account data, keyed by the new application ID.
 
         Continue to step 2.

--- a/dev/ledger.md
+++ b/dev/ledger.md
@@ -1064,7 +1064,7 @@ point must be discarded and the entire transaction rejected.
 - Local state may be read for any opted-in application present in the
   sender’s account data, or in the account data for any address listed
   in the transaction’s `Accounts` field. An attempt to read local
-  state from any other tea account will cause program execution to
+  state from any other account will cause program execution to
   fail. Further, in TEAL programs version 4 or later, Local state
   reads are restricted by application ID in the same way as Global
   state reads.

--- a/dev/ledger.md
+++ b/dev/ledger.md
@@ -364,15 +364,14 @@ account state, indexed by the application ID. This map is encoded as msgpack
 field `appp`. The maximum number of applications that a single account may
 create is 10. Creating one application increases the minimum balance
 requirements of the creator by 100000 microalgos, plus the [`GlobalStateSchema`
-Minimum Balance contribution][State Schema Minimum Balance Contribution].
+Minimum Balance contribution][App Minimum Balance Increases].
 
 `LocalState` for applications that an account has opted in to are also stored in
 a map in the account state, indexed by the application ID. This map is encoded
 as msgpack field `appl`. The maximum number of applications that a single
 account may opt in to is 10. Opting in to one application increases the minimum
 balance requirements of the opting-in account by 100000 microalgos plus the
-[`LocalStateSchema` Minimum Balance contribution][State Schema Minimum Balance
-Contribution].
+[`LocalStateSchema` Minimum Balance contribution][App Minimum Balance Increases].
 
 ### TEAL Key/Value Stores
 
@@ -407,7 +406,7 @@ A state schema is composed of two fields:
 - `NumByteSlice`, encoded as msgpack field `nbs`. This field represents the
   maximum number of byte slice values that may appear in some TKV.
 
-#### State Schema Minimum Balance Contribution
+#### App Minimum Balance Increases
 
 When an account opts in to an application or creates an application, the
 minimum balance requirements for that account increase.
@@ -416,13 +415,15 @@ When opting in to an application, there is a base minimum balance increase
 of 100000 microalgos. There is an additional minimum balance increase based on
 the `LocalStateSchema` for that application, described by following formula:
 
-`28500 * shema.NumUint + 50000 * schema.NumByteSlice` microalgos.
+`28500 * schema.NumUint + 50000 * schema.NumByteSlice` microalgos.
 
-When creating an application, there is a base minimum balance increase of
-100000 microalgos. There is an additional minimum balance increase based on the
-`GlobalStateSchema` for that application, described by the following formula:
+When creating an application, there is a base minimum balance increase
+of 100000 microalgos. There is an additional minimum blance increase
+of `100000 * ExtraProgramPages` microalgos.  Finally, there is an
+additional minimum balance increase based on the `GlobalStateSchema`
+for that application, described by the following formula:
 
-`28500 * shema.NumUint + 50000 * schema.NumByteSlice` microalgos.
+`28500 * schema.NumUint + 50000 * schema.NumByteSlice` microalgos.
 
 ## Assets
 

--- a/dev/ledger.md
+++ b/dev/ledger.md
@@ -1036,13 +1036,15 @@ point must be discarded and the entire transaction rejected.
 
 ### Application Stateful TEAL Execution Semantics
 
-- During the execution of an `ApprovalProgram` or `ClearStateProgram`, the
-  application’s `LocalStateSchema` and `GlobalStateSchema` may never be
-  violated. The program's execution will fail on the first instruction that
-  would cause the relevant schema to be violated. Writing a `Bytes` value to a
-  local or global [TEAL Key/Value Store][TEAL Key/Value Stores] longer than 64
-  bytes, or writing any value to a key longer than 64 bytes, will likewise cause
-  the program to fail on the offending instruction.
+- During the execution of an `ApprovalProgram` or `ClearStateProgram`,
+  the application’s `LocalStateSchema` and `GlobalStateSchema` may
+  never be violated. The program's execution will fail on the first
+  instruction that would cause the relevant schema to be
+  violated. Writing a `Bytes` value to a local or global [TEAL
+  Key/Value Store][TEAL Key/Value Stores] such that the sum of the
+  lengths of the key and value in bytes exceeds 128, or writing any
+  value to a key longer than 64 bytes, will likewise cause the program
+  to fail on the offending instruction.
 - Global state may only be read for the application ID whose program is
   executing, or for any application ID mentioned in the `ForeignApps`
   transaction field. An attempt to read global state for another application

--- a/dev/ledger.md
+++ b/dev/ledger.md
@@ -453,7 +453,7 @@ which can be encoded as a msgpack struct:
 
  - A string representing a URL that provides further description of the asset,
    encoded with msgpack field `au`.  As above, this does not uniquely identify
-   an asset.  The maximum length of this field is 32 bytes.
+   an asset.  The maximum length of this field is 96 bytes.
 
  - A 32-byte hash specifying a commitment to asset-specific metadata, encoded with
    msgpack field `am`.  As above, this does not uniquely identify an asset.

--- a/dev/ledger.md
+++ b/dev/ledger.md
@@ -325,7 +325,9 @@ parameters_, which can be encoded as a msgpack struct:
   global state associated with this application. This field is encoded with
   msgpack field `approv`.
 
-  The cost of the program during execution must not exceed 700.
+  For Version 3 or lower TEAL programs, the cost of the program as determined by the Stateful TEAL `Check` function must not exceed 700.
+
+  For Version 4 or higher TEAL programs, the cost of the program during execution must not exceed 700.
 
 - A mutable Stateful TEAL "Clear State" program (`ClearStateProgram`), executed
   when an opted-in user forcibly removes the local application state associated
@@ -336,7 +338,9 @@ parameters_, which can be encoded as a msgpack struct:
   global state associated with this application. This field is encoded with
   msgpack field `clearp`.
 
-  The cost of the program during execution must not exceed 700.
+  For Version 3 or lower TEAL programs, the cost of the program as determined by the Stateful TEAL `Check` function must not exceed 700.
+
+  For Version 4 or higher TEAL programs, the cost of the program during execution must not exceed 700.
 
 - An immutable "global state schema" (`GlobalStateSchema`), which sets a limit
   on the size of the global [TEAL Key/Value Store][TEAL Key/Value Stores] that

--- a/dev/ledger.md
+++ b/dev/ledger.md
@@ -871,7 +871,9 @@ the transactions have nonzero "Group", compute the _TxGroup hash_ as follows:
 
 If the TxGroup hash of any transaction group in a block does not match the "Group" field of the transactions in that group (and that "Group" field is nonzero), then the block is invalid. Additionally, if a block contains a transaction group of more than $G_{max}$ transactions, the block is invalid.
 
-Beyond this check, each transaction in a group is evaluated separately and must be valid on its own, as described below in the [Validity and State Changes][Validity and State Changes] section. For example, a group containing a zero-fee transaction and a very-high-fee transaction would be rejected because the first transaction has fee less than $f_{\min}$, even if the average transaction fee of the group were above $f_{\min}$. As another example, an account with balance 50 could not spend 100 in transaction A and afterward receive 500 in transaction B, even if transactions A and B are in the same group, because transaction A would leave the account with a negative balance.
+If the sum of the fees paid by the transactions in a transaction group is less than $f_{\min}$ times the number of transactions in the group, then the block is invalid.
+
+Beyond the TxGroup and MinFee checks, each transaction in a group is evaluated separately and must be valid on its own, as described below in the [Validity and State Changes][Validity and State Changes] section. For example, an account with balance 50 could not spend 100 in transaction A and afterward receive 500 in transaction B, even if transactions A and B are in the same group, because transaction A would leave the account with a negative balance.
 
 ## Asset Transaction Semantics
 

--- a/dev/ledger.md
+++ b/dev/ledger.md
@@ -325,8 +325,7 @@ parameters_, which can be encoded as a msgpack struct:
   global state associated with this application. This field is encoded with
   msgpack field `approv`.
 
-  This field must not exceed 1024*(1+`ExtraProgramPages`) bytes. The
-  cost of the program during execution must not exceed 700.
+  The cost of the program during execution must not exceed 700.
 
 - A mutable Stateful TEAL "Clear State" program (`ClearStateProgram`), executed
   when an opted-in user forcibly removes the local application state associated
@@ -337,8 +336,7 @@ parameters_, which can be encoded as a msgpack struct:
   global state associated with this application. This field is encoded with
   msgpack field `clearp`.
 
-  This field must not exceed 1024*(1+`ExtraProgramPages`) bytes. The
-  cost of the program as during execution must not exceed 700.
+  The cost of the program during execution must not exceed 700.
 
 - An immutable "global state schema" (`GlobalStateSchema`), which sets a limit
   on the size of the global [TEAL Key/Value Store][TEAL Key/Value Stores] that
@@ -354,6 +352,12 @@ parameters_, which can be encoded as a msgpack struct:
   field `lsch`.
 
   The maximum number of values that this schema may permit is 16.
+
+- An immutable "extra pages" value (`ExtraProgramPages`), which limits
+  the total size of the programs of the application. The sum of the
+  lengths of `ApprovalProgram` and `ClearStateProgram` may not exceed
+  2048*(1+`ExtraProgramPages`) bytes. This field is encoded with
+  msgpack field `epp` and may not exceed 3.
 
 - The "global state" (`GlobalState`) associated with this application, stored as
   a [TEAL Key/Value Store][TEAL Key/Value Stores]. This field is encoded with


### PR DESCRIPTION
These are new opcodes to support use-cases such as compiling to TEAL, or more complicated math in AMMs or token bridges.

