### PR TITLE
Fix typo in vote verification conditions

### DIFF
--- a/dev/abft.md
+++ b/dev/abft.md
@@ -275,7 +275,7 @@ unambiguous) if the following conditions are true:
  - If $s \in \{\Propose, \Soft, \Cert, \Late, \Redo\}$, $v \neq \bot$.
    Conversely, if $s = \Down$, $v = \bot$.
 
- - Let $(\pk, B) = (\Record(L, r - \delta_b), I)$,
+ - Let $(\pk, B) = \Record(L, r - \delta_b, I)$,
    $\Bbar = \Stake(L, r - \delta_b)$, $Q = \Seed(L, r - \delta_s)$,
    $\tau = \CommitteeThreshold(s)$, and
    $\taubar = \CommitteeSize(s)$.  


### PR DESCRIPTION
In the Algorand BFT spec section listing conditions for a valid vote, the first invocation of `\Record`:
```
Let $(\pk, B) = (\Record(L, r - \delta_b), I)$,
```

Doesn't match the definition of `\Record` earlier:
```
_Record Lookup_: $\Record(L, r, I_k) = (\pk_{k,r}, B_{k,r})$
```
or other uses of `\Record` later in the spec, such as in the conditions for a valid proposal and a valid seed:
```
Let $(B, \pk) = \Record(L, r - \delta_b, I)$.
...
Let $(B, \pk) = \Record(L, r - \delta_b, I)$; let $q_0 = \Seed(L, r-\delta_s)$.
```