### PR TITLE
Specify current ledger consensus parameters

### DIFF
--- a/dev/abft.md
+++ b/dev/abft.md
@@ -53,7 +53,7 @@ The protocol is parameterized by the following constants:
 For convenience, we define $\delta_b$ (the "balance lookback") to be
 $2\delta_s\delta_r$.
 
-Algorand v1 sets $\delta_s = 2$, $\delta_r = 80$, $\lambda = 4$ seconds,
+Algorand v1 sets $\delta_s = 2$, $\delta_r = 80$, $\lambda = 2$ seconds,
 $\lambda_f = 5$ minutes, and $\Lambda = 17$ seconds.
 
 Identity, Authorization, and Authentication

--- a/dev/ledger.md
+++ b/dev/ledger.md
@@ -14,14 +14,23 @@ abstract: >
 The Algorand Ledger is parameterized by the following values:
 
  - $t_{\delta}$, the maximum difference between successive timestamps.
+   Currently defined as 25 seconds.
  - $T_{\max}$, the length of the _transaction tail_.
+   Currently defined as 1000.
  - $B_{\max}$, the maximum number of transaction bytes in a block.
+   Currently defined as 1,000,000.
  - $b_{\min}$, the minimum balance for any address.
+   Currently defined as 100,000 microAlgos.
  - $f_{\min}$, the minimum processing fee for any transaction.
+   Currently defined as 1000 microAlgos.
  - $V_{\max}$, the maximum length of protocol version strings.
+   Currently defined as 128.
  - $N_{\max}$, the maximum length of a transaction note string.
+   Currently defined as 1024 bytes.
  - $G_{\max}$, the maximum number of transactions allowed in a transaction group.
+   Currently defined as 16.
  - $\tau$, the number of votes needed to execute a protocol upgrade.
+   Currently defined as 9000.
  - $\delta_d$, the number of rounds over with an upgrade proposal is open.
    Currently defined as 10,000.
  - $\delta_{x_{\min}}$ and $\delta_{x_{\max}}$, the minimum and maximum number
@@ -30,7 +39,9 @@ The Algorand Ledger is parameterized by the following values:
  - $\delta_x$, the default number of rounds needed to prepare for an upgrade.
    Currently defined as 140,000.
  - $\omega_r$, the rate at which the reward rate is refreshed.
+   Currently defined as 500,000.
  - $A$, the size of an earning unit.
+   Currently defined as 1,000,000 microAlgos.
 
 ## States
 


### PR DESCRIPTION
This sets the current values of parameters defined in ledger.md to their current values as of the latest consensus version. We plan to change one or more of them in an upcoming update, so establishing their current values in this PR first will make it easier to review those changes.

These values can be found in https://github.com/algorand/go-algorand/blob/master/config/consensus.go

I also updated a typo in the value of $\lambda$ in abft.md to be 2s instead of 4s. The soft/filter timeout has always been 4s, but the language of the abft.md spec uses $2\lambda$ (which would be 8s without this fix) whenever $\lambda$ appears in descriptions of the filter timeout. In the code, a consensus parameter called SmallLambda (2s) and 2*SmallLambda was similarly [originally used to calculate the filter timeout](https://github.com/algorand/go-algorand/pull/1520/files#diff-a75ef7294adbd7ae646c49ae2a518253936983c0a16594b84f20f15403767a2fL527), which similarly results in 4s.