### PR TITLE
abft.md: reduce lambda_0 to 1.5s

### DIFF
--- a/dev/abft.md
+++ b/dev/abft.md
@@ -63,7 +63,7 @@ We define $\FilterTimeout(p)$ on period $p$ as follows:
     - $\FilterTimeout(p) = 2\lambda$
 
 Algorand sets $\delta_s = 2$, $\delta_r = 80$, $\lambda = 2$ seconds,
-$\lambda_0 = 1.7$ seconds, $\lambda_f = 5$ minutes, and $\Lambda = 17$ seconds.
+$\lambda_0 = 1.5$ seconds, $\lambda_f = 5$ minutes, and $\Lambda = 17$ seconds.
 
 Identity, Authorization, and Authentication
 ===========================================


### PR DESCRIPTION
Changes $\lambda_0$ in the consensus spec to match the change in #90.