### PR TITLE
add description of new SHA-512 usage

### DIFF
--- a/dev/crypto.md
+++ b/dev/crypto.md
@@ -100,9 +100,13 @@ for the Byzantine Fault Tolerance protocol, and (2) rerandomize its
 random seed.
 
 ### SHA256
-Algorand uses [SHA-256 algorithm][sha256] to allow verification of Algorand's state and transactions
+Algorand uses [SHA-256 algorithm][rfcsha] to allow verification of Algorand's state and transactions
 on environments where SHA512_256 is not supported.
 
+### SHA512
+Algorand uses the [SHA-512 algorithm][rfcsha] to strengthen post-quantum security
+for the previous block hash (`prev512`) and transaction commitment (`txn512`)
+in the block header by increasing collision resistance against Grover's algorithm.
 
 ### SUBSET-SUM
 Algorand uses [SUBSET-SUM algorithm][sumhash] which is a quantum-resilient hash function.
@@ -523,7 +527,7 @@ Since the quantum-secure verifier is not bottlenecked by reveals, we can take ${
 [abft-spec]: https://github.com/algorand/spec/abft.md
 
 [sha]: https://doi.org/10.6028/NIST.FIPS.180-4
-[sha256]: https://datatracker.ietf.org/doc/html/rfc4634
+[rfcsha]: https://datatracker.ietf.org/doc/html/rfc4634
 [sumhash]: https://github.com/algorandfoundation/specs/blob/master/dev/cryptographic-specs/sumhash-spec.pdf
 [ed25519]: https://tools.ietf.org/html/rfc8032
 [msgpack]: https://github.com/msgpack/msgpack/blob/master/spec.md

--- a/dev/ledger.md
+++ b/dev/ledger.md
@@ -120,12 +120,19 @@ The block header contains the following components:
  - A cryptographic commitment to the block's _transaction sequence_, described
    below, stored under msgpack key `txn`.
 
- - A cryptographic commitment, using SHA256 hash function, to the block's _transaction sequence_, described
+ - A cryptographic commitment, using the SHA256 hash function, to the block's _transaction sequence_, described
    below, stored under msgpack key `txn256`.
+
+ - A cryptographic commitment, using the SHA512 hash function, to the block's _transaction sequence_, described
+   below, stored under msgpack key `txn512`.
 
  - The block's _previous hash_, which is the cryptographic hash of the previous
    block in the sequence.  (The previous hash of the genesis block is 0.)  The
    previous hash is stored under msgpack key `prev`.
+
+ - The block's _previous SHA512 hash_, which is exactly like the `prev` hash,
+   but uses the SHA512 hash function. This previous SHA512 hash is stored under
+   msgpack key `prev512`.
 
  - The block's _transaction counter_, which is the total number of transactions
    issued prior to this block.  This count starts from the first block with a
@@ -1180,15 +1187,18 @@ The transaction commitment for a block covers the transaction encodings
 with the changes described above.  Individual transaction signatures
 cover the original encoding of transactions as standalone.
 
-In addition to _transaction commitment_, each block will also contain _SHA256 transaction commitment_.
-It can allow a verifier which does not support SHA512_256 function to verify proof of membership on transaction.
-In order to construct this commitment we use Vector Commitment. The leaves in the Vector Commitment
-tree are hashed as $$SHA256("TL", txidSha256, stibSha256)$$.  Where:
+In addition, each block will also contain _SHA256 and SHA512 transaction commitments_.
+They allow a verifier which does not support SHA512_256 to verify proof of membership for transactions.
+In order to construct these commitments, we use a vector commitment. The leaves in the vector commitment
+tree are hashed as $$SHA256("TL", txidSha256, stibSha256)$$ and $$SHA512("TL", txidSha512, stibSha512)$$, respectively.
+Where:
 
-- txidSha256 = SHA256(`TX` || transcation)
+- txidSha256 = SHA256(`TX` || transaction)
 - stibSha256 = SHA256(`STIB` || signed transaction || ApplyData)
+- txidSha512 = SHA512(`TX` || transaction)
+- stibSha512 = SHA512(`STIB` || signed transaction || ApplyData)
 
-The vector commitment uses SHA256 for internal nodes as well.
+These vector commitments use SHA256 or SHA512 for internal nodes as well.
 
 A valid transaction sequence contains no duplicates: each transaction in the
 transaction sequence appears exactly once.  We can call the set of these


### PR DESCRIPTION
In https://github.com/algorand/go-algorand/pull/6339 new fields `prev512` and `txn512` were added to the block header. This PR documents these additions, following previous SHA-256 documentation added in https://github.com/algorandfoundation/specs/pull/67