### PR TITLE
build: no longer fail for outside PRs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,10 +38,12 @@ jobs:
         with:
           name: mdbook-build
           path: book
+          retention-days: 1
 
   deployment:
     needs:
       - integration
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     name: Run Cloudflare Deployment
     steps:


### PR DESCRIPTION
If these artifacts have another use other than deployments, pleast let me know.