### PR TITLE
chore: update release artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,8 +40,7 @@ jobs:
       - name: Prepare artifacts
         run: |
           mkdir -p release-artifacts
-          tar -czf release-artifacts/specs-html-${{ steps.sha.outputs.sha }}.tar.gz -C book/html .
-          cp book/pandoc/pdf/algorand-specs.pdf release-artifacts/specs-pdf-${{ steps.sha.outputs.sha }}.pdf
+          cp book/pandoc/pdf/algorand-specs.pdf release-artifacts/algorand-specs-${{ steps.sha.outputs.sha }}.pdf
 
       - name: Create Draft Release and Upload Artifacts
         uses: softprops/action-gh-release@v2
@@ -49,6 +48,4 @@ jobs:
           tag_name: ${{ steps.sha.outputs.sha }}
           name: ${{ steps.sha.outputs.sha }}
           draft: true
-          files: |
-            release-artifacts/specs-html-${{ steps.sha.outputs.sha }}.tar.gz
-            release-artifacts/specs-pdf-${{ steps.sha.outputs.sha }}.pdf
+          files: release-artifacts/specs-pdf-${{ steps.sha.outputs.sha }}.pdf

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,4 +48,4 @@ jobs:
           tag_name: ${{ steps.sha.outputs.sha }}
           name: ${{ steps.sha.outputs.sha }}
           draft: true
-          files: release-artifacts/specs-pdf-${{ steps.sha.outputs.sha }}.pdf
+          files: release-artifacts/algorand-specs-${{ steps.sha.outputs.sha }}.pdf

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,6 +21,8 @@ services:
       - 3000:3000
       - 3001:3001
     command: ["serve", "--hostname", "0.0.0.0"]
+    profiles:
+      - release
     volumes:
       - ./src:/book/src
       - ./book:/book/book


### PR DESCRIPTION
The release artifacts now include just the PDF book, as the HTML is already hosted on the specs website, which could more conveniently be built and served locally with `docker compose up`.