### PR TITLE
docs: post quantum account

### DIFF
--- a/src/avm/avm-mode-logic-signatures.md
+++ b/src/avm/avm-mode-logic-signatures.md
@@ -9,15 +9,19 @@ $$
 Logic Signatures execute as part of testing a proposed transaction to see if it is
 valid and authorized to be committed into a block. If an authorized program executes
 and finishes with a single non-zero `uint64` value on the Stack, then that program
-has validated the transaction it is attached to.
+has validated (approved) the transaction it is attached to.
+
+A Logic Signature is carried in the `lsig` field of a `SignedTxn` structure: the
+_program_ bytecode is the msgpack field `l` and the **OPTIONAL** _arguments_ are
+the field `arg` (see [Authorization and Signatures](../ledger/ledger-txn-authorization.md)).
 
 The program has access to data from the transaction it is attached to (`txn` opcode),
 any transactions in a transaction group it is part of (`gtxn` opcode), and a few
 global values like consensus parameters (`global` opcode).
 
-Some _arguments_ may be attached to a transaction being validated by a program. Arguments
-are an array of byte strings. A common pattern would be to have the key to unlock
-some contract as an argument.
+Arguments are an array of byte strings. A common pattern would be to have the key
+to unlock some contract as an argument. Note that Logic Signature arguments are
+_not_ signed.
 
 Be aware that Logic Signature arguments are recorded on the blockchain and publicly
 visible when the transaction is submitted to the network, even before the transaction
@@ -52,23 +56,27 @@ The total program cost of all Logic Signatures in a group **MUST NOT** exceed
 ## Modes
 
 A program can either authorize some _delegated action_ on a normal signature-based,
-multisignature-based, or post-quantum account or be wholly in charge of a _contract
-account_.
+multisignature-based, or post-quantum signature-based account or be wholly in charge
+of a _contract account_.
 
 ### Delegated Signature Mode
 
-If the account has signed the program (by providing a valid [Ed25519](../crypto/crypto-ed25519.md)
-signature from the authorizer address on the string `Program` concatenated with
-the program bytecode, or a valid multisignature for the authorizer address on the
-string `MsigProgram` concatenated with the authorizer address and the program
-bytecode) then, if the program returns `True`, the transaction is authorized as
-if the account had signed it. A post-quantum account
-instead signs the hash of the string `PQProgram` concatenated with the authorizer
-address and the program bytecode (see
-[Logic Signature Delegation](../ledger/ledger-txn-authorization.md#logic-signature-delegation)).
-This allows an account to hand out a signed program so that other users can carry
-out delegated actions that are approved by the program. Note that Logic Signature
-arguments are _not_ signed.
+In this mode, the account signs the program by providing exactly one of the following:
+
+- An [Ed25519](../crypto/crypto-ed25519.md) signature (`lsig` field `sig`), for a
+normal signature-based account;
+
+- A multisignature (field `lmsig`), for a multisignature-based account;
+
+- A post-quantum signature (field `pqsig`), for a post-quantum signature-based account.
+
+The signed messages and validity conditions are defined in the
+[Logic Signature Delegation](../ledger/ledger-txn-authorization.md#logic-signature-delegation)
+section of the ledger specifications.
+
+If the program is properly signed and approves, the transaction is authorized as
+if the account had signed it. This allows an account to hand out a signed program
+so that other users can carry out delegated actions that are approved by the program.
 
 ### Contract Account Mode
 

--- a/src/avm/avm-mode-logic-signatures.md
+++ b/src/avm/avm-mode-logic-signatures.md
@@ -51,18 +51,22 @@ The total program cost of all Logic Signatures in a group **MUST NOT** exceed
 
 ## Modes
 
-A program can either authorize some _delegated action_ on a normal signature-based
-or multisignature-based account or be wholly in charge of a _contract account_.
+A program can either authorize some _delegated action_ on a normal signature-based,
+multisignature-based, or post-quantum account or be wholly in charge of a _contract
+account_.
 
 ### Delegated Signature Mode
 
 If the account has signed the program (by providing a valid [Ed25519](../crypto/crypto-ed25519.md)
 signature or valid multisignature for the authorizer address on the string `Program`
 concatenated with the program bytecode) then, if the program returns `True`, the
-transaction is authorized as if the account had signed it. This allows an account
-to hand out a signed program so that other users can carry out delegated actions
-that are approved by the program. Note that Logic Signature arguments are _not_
-signed.
+transaction is authorized as if the account had signed it. A post-quantum account
+instead signs the hash of the string `PQProgram` concatenated with the authorizer
+address and the program bytecode (see
+[Logic Signature Delegation](../ledger/ledger-txn-authorization.md#logic-signature-delegation)).
+This allows an account to hand out a signed program so that other users can carry
+out delegated actions that are approved by the program. Note that Logic Signature
+arguments are _not_ signed.
 
 ### Contract Account Mode
 

--- a/src/avm/avm-mode-logic-signatures.md
+++ b/src/avm/avm-mode-logic-signatures.md
@@ -58,9 +58,11 @@ account_.
 ### Delegated Signature Mode
 
 If the account has signed the program (by providing a valid [Ed25519](../crypto/crypto-ed25519.md)
-signature or valid multisignature for the authorizer address on the string `Program`
-concatenated with the program bytecode) then, if the program returns `True`, the
-transaction is authorized as if the account had signed it. A post-quantum account
+signature from the authorizer address on the string `Program` concatenated with
+the program bytecode, or a valid multisignature for the authorizer address on the
+string `MsigProgram` concatenated with the authorizer address and the program
+bytecode) then, if the program returns `True`, the transaction is authorized as
+if the account had signed it. A post-quantum account
 instead signs the hash of the string `PQProgram` concatenated with the authorizer
 address and the program bytecode (see
 [Logic Signature Delegation](../ledger/ledger-txn-authorization.md#logic-signature-delegation)).

--- a/src/avm/avm-mode-logic-signatures.md
+++ b/src/avm/avm-mode-logic-signatures.md
@@ -13,21 +13,19 @@ has validated (approved) the transaction it is attached to.
 
 A Logic Signature is carried in the `lsig` field of a `SignedTxn` structure: the
 _program_ bytecode is the msgpack field `l` and the **OPTIONAL** _arguments_ are
-the field `arg` (see [Authorization and Signatures](../ledger/ledger-txn-authorization.md)).
+the field `arg`, an array of byte strings. The `lsig` structure is defined in the
+[Authorization and Signatures](../ledger/ledger-txn-authorization.md) section of
+the Ledger specifications.
 
 The program has access to data from the transaction it is attached to (`txn` opcode),
 any transactions in a transaction group it is part of (`gtxn` opcode), and a few
 global values like consensus parameters (`global` opcode).
 
-Arguments are an array of byte strings. A common pattern would be to have the key
-to unlock some contract as an argument. Note that Logic Signature arguments are
-_not_ signed.
-
-Be aware that Logic Signature arguments are recorded on the blockchain and publicly
-visible when the transaction is submitted to the network, even before the transaction
-has been included in a block. These arguments are _not_ part of the transaction ID
-nor of the [transaction group](../ledger/ledger-txn-groups.md) hash (`grp`). They
-also cannot be read from other programs in the group of transactions.
+Logic Signature arguments are _not_ signed, they are not covered by any delegation
+signature and are recorded on the blockchain, publicly visible as soon as the transaction
+is submitted to the network, even before it has been included in a block. These
+arguments are _not_ part of the transaction ID nor of the [transaction group](../ledger/ledger-txn-groups.md)
+hash (`grp`). They also cannot be read from other programs in the group of transactions.
 
 ## Bytecode Size
 
@@ -55,16 +53,14 @@ The total program cost of all Logic Signatures in a group **MUST NOT** exceed
 
 ## Modes
 
-A program can either authorize some _delegated action_ on a normal signature-based,
-multisignature-based, or post-quantum signature-based account or be wholly in charge
-of a _contract account_.
+A program can either authorize some _delegated action_ on a normal signature-based
+account or be wholly in charge of a _contract account_.
 
 ### Delegated Signature Mode
 
 In this mode, the account signs the program by providing exactly one of the following:
 
-- An [Ed25519](../crypto/crypto-ed25519.md) signature (`lsig` field `sig`), for a
-normal signature-based account;
+- A signature (field `sig`), for a normal signature-based account;
 
 - A multisignature (field `lmsig`), for a multisignature-based account;
 

--- a/src/crypto/crypto-domain-separators.md
+++ b/src/crypto/crypto-domain-separators.md
@@ -21,6 +21,9 @@ The list below specifies each `prefix`:
   - `BR`: A _Balance Record_.
   - `GE`: A _Genesis_ configuration.
   - `PQA`: A [_post-quantum account address_](../ledger/ledger-txn-authorization.md#post-quantum-signature).
+  - `PQProgram`: A logic signature program delegation by a
+  [post-quantum account](../ledger/ledger-txn-authorization.md#logic-signature-delegation)
+  (the delegating account address concatenated with the program bytecode).
   - `spm`: A _State Proof_ message.
   - `STIB`: A _SignedTxnInBlock_ that appears as part of the leaf in the Merkle
   tree of transactions.

--- a/src/crypto/crypto-domain-separators.md
+++ b/src/crypto/crypto-domain-separators.md
@@ -20,6 +20,9 @@ The list below specifies each `prefix`:
   - `BH`: A _Block Header_.
   - `BR`: A _Balance Record_.
   - `GE`: A _Genesis_ configuration.
+  - `MsigProgram`: A logic signature program delegation by a
+  [multisignature account](../avm/avm-mode-logic-signatures.md#delegated-signature-mode)
+  (the delegating account address concatenated with the program bytecode).
   - `PQA`: A [_post-quantum account address_](../ledger/ledger-txn-authorization.md#post-quantum-signature).
   - `PQProgram`: A logic signature program delegation by a
   [post-quantum account](../ledger/ledger-txn-authorization.md#logic-signature-delegation)

--- a/src/crypto/crypto-domain-separators.md
+++ b/src/crypto/crypto-domain-separators.md
@@ -20,6 +20,7 @@ The list below specifies each `prefix`:
   - `BH`: A _Block Header_.
   - `BR`: A _Balance Record_.
   - `GE`: A _Genesis_ configuration.
+  - `PQA`: A [_post-quantum account address_](../ledger/ledger-txn-authorization.md#post-quantum-signature).
   - `spm`: A _State Proof_ message.
   - `STIB`: A _SignedTxnInBlock_ that appears as part of the leaf in the Merkle
   tree of transactions.
@@ -42,6 +43,8 @@ The list below specifies each `prefix`:
   number of the ARC). For example, ARC-0003 can use any prefix starting with `arc0003`.
   - `MX`: An arbitrary message used to prove ownership of a cryptographic secret.
   - `NPR`: A message that proves a peer’s stake in an Algorand networking implementation.
+  - `PQK`: The derivation of a post-quantum signing key seed from master entropy
+  (used by key management tools).
   - `TE`: An arbitrary message reserved for testing purposes.
   - `Program`: A TEAL bytecode program.
   - `ProgData`: Data that is signed within TEAL bytecode programs.

--- a/src/crypto/crypto-falcon.md
+++ b/src/crypto/crypto-falcon.md
@@ -19,4 +19,3 @@ The library defines the following sizes:
 | Private Key            |               \\( 2305 \\)                |
 | Signature - CT Format  |               \\( 1538 \\)                |
 | Signature - Compressed | Variable, up to a maximum of \\( 1423 \\) |
-

--- a/src/crypto/crypto-falcon.md
+++ b/src/crypto/crypto-falcon.md
@@ -11,6 +11,8 @@ from post-quantum accounts (scheme identifier `f1`, see
 FALCON signatures contain a _salt version_. Algorand only accepts signatures with
 a salt version equal to `0`.
 
+FALCON-1024 signatures **MUST** be in compressed format.
+
 The library defines the following sizes:
 
 | Component              |               Size (bytes)                |

--- a/src/crypto/crypto-falcon.md
+++ b/src/crypto/crypto-falcon.md
@@ -4,7 +4,9 @@ Algorand uses a [deterministic](../../_archive/dev/cryptographic-specs/falcon-de
 version of [FALCON lattice-based signature scheme](https://falcon-sign.info/falcon.pdf).
 
 FALCON is _quantum-resilient_ and a _SNARK-friendly_ digital signature scheme used
-to sign in State Proofs.
+to sign in State Proofs and to authorize transactions from post-quantum accounts
+(scheme identifier `f1`, see
+[Authorization and Signatures](../ledger/ledger-txn-authorization.md#post-quantum-signature)).
 
 FALCON signatures contain a _salt version_. Algorand only accepts signatures with
 a salt version equal to `0`.
@@ -18,4 +20,3 @@ The library defines the following sizes:
 | Signature - CT Format  |               \\( 1538 \\)                |
 | Signature - Compressed | Variable, up to a maximum of \\( 1423 \\) |
 
-Algorand uses a _random seed_ of \\( 48 \\) bytes for FALCON key generation.

--- a/src/crypto/crypto-falcon.md
+++ b/src/crypto/crypto-falcon.md
@@ -4,8 +4,8 @@ Algorand uses a [deterministic](../../_archive/dev/cryptographic-specs/falcon-de
 version of [FALCON lattice-based signature scheme](https://falcon-sign.info/falcon.pdf).
 
 FALCON is _quantum-resilient_ and a _SNARK-friendly_ digital signature scheme used
-to sign in State Proofs and to authorize transactions from post-quantum accounts
-(scheme identifier `f1`, see
+to sign in State Proofs, and to authorize transactions and delegate logic signatures
+from post-quantum accounts (scheme identifier `f1`, see
 [Authorization and Signatures](../ledger/ledger-txn-authorization.md#post-quantum-signature)).
 
 FALCON signatures contain a _salt version_. Algorand only accepts signatures with

--- a/src/crypto/crypto-falcon.md
+++ b/src/crypto/crypto-falcon.md
@@ -1,6 +1,6 @@
 # FALCON
 
-Algorand uses a [deterministic](../../_archive/dev/cryptographic-specs/falcon-deterministic.pdf)
+Algorand uses a [deterministic](https://github.com/algorandfoundation/specs/blob/master/_archive/dev/cryptographic-specs/falcon-deterministic.pdf)
 version of [FALCON lattice-based signature scheme](https://falcon-sign.info/falcon.pdf).
 
 FALCON is _quantum-resilient_ and a _SNARK-friendly_ digital signature scheme used

--- a/src/crypto/crypto-falcon.md
+++ b/src/crypto/crypto-falcon.md
@@ -8,7 +8,9 @@ to sign in State Proofs, and to authorize transactions and delegate logic signat
 from post-quantum accounts (scheme identifier `f1`, see
 [Authorization and Signatures](../ledger/ledger-txn-authorization.md#post-quantum-signature)).
 
-FALCON signatures contain a _salt version_.
+FALCON signatures contain a _salt version_. In State Proofs, every revealed
+signature **MUST** match the salt version declared by the proof. Post-quantum
+account signatures are not constrained by the salt version.
 
 FALCON-1024 signatures **MUST** be in compressed format.
 

--- a/src/crypto/crypto-falcon.md
+++ b/src/crypto/crypto-falcon.md
@@ -8,8 +8,7 @@ to sign in State Proofs, and to authorize transactions and delegate logic signat
 from post-quantum accounts (scheme identifier `f1`, see
 [Authorization and Signatures](../ledger/ledger-txn-authorization.md#post-quantum-signature)).
 
-FALCON signatures contain a _salt version_. Algorand only accepts signatures with
-a salt version equal to `0`.
+FALCON signatures contain a _salt version_.
 
 FALCON-1024 signatures **MUST** be in compressed format.
 

--- a/src/crypto/crypto-state-proofs.md
+++ b/src/crypto/crypto-state-proofs.md
@@ -211,8 +211,8 @@ array of participants, if:
 - The depth of the vector commitment for the signature and the participant information
 should be less than or equal to \\( 20 \\),
 
-- All FALCON signatures should have the same salt version, and it should be equal
-to the salt version specified in the State Proof,
+- Every revealed FALCON signature **MUST** have a salt version equal to the salt
+version specified in the State Proof,
 
 - The number of reveals in the State Proof should be less than or equal to \\( 640 \\),
 

--- a/src/keys/keys-root.md
+++ b/src/keys/keys-root.md
@@ -15,7 +15,12 @@ version, the authorization threshold, and all the participating public keys;
 
 - A [logic signature](../avm/avm-mode-logic-signatures.md#contract-account-mode)
 program, wholly in charge of a _contract account_. The account address is derived
-by hashing the program bytecode.
+by hashing the program bytecode;
+
+- A post-quantum scheme key pair. The account address is derived by hashing the
+scheme identifier, an address salt, and the public key, as specified in the
+[Post-Quantum Signature](../ledger/ledger-txn-authorization.md#post-quantum-signature)
+section of the Ledger specification.
 
 Regardless of the authorization method, root keys are used to authorize transaction
 messages as well as delegating the voting authentication using _voting keys_, unless

--- a/src/keys/keys-root.md
+++ b/src/keys/keys-root.md
@@ -1,10 +1,26 @@
 # Root Keys
 
-Root keys are used to identify ownership of an account. An Algorand node only interacts with
-the public key of a root key. The public key of a root key is also used as the account
-address. Root keys are used to sign transaction messages as well as delegating the
-voting authentication using _voting keys_, unless that specific account was rekeyed. A rekeyed
-account would use the rekeyed key in lieu of the root key.
+Root keys are used to identify ownership of an account. An Algorand node only
+interacts with the public part of a root key (public keys or program bytecode).
+
+Each account is controlled by a _root_ authorization method, which also binds the
+account address to the authorization material:
+
+- A single [Ed25519](../crypto/crypto-ed25519.md) key pair. The public key of the
+root key is used directly as the account address;
+
+- A [multisignature](../ledger/ledger-txn-authorization.md#multisignature) composition
+of Ed25519 key pairs. The account address is derived by hashing the multisignature
+version, the authorization threshold, and all the participating public keys;
+
+- A [logic signature](../avm/avm-mode-logic-signatures.md#contract-account-mode)
+program, wholly in charge of a _contract account_. The account address is derived
+by hashing the program bytecode.
+
+Regardless of the authorization method, root keys are used to authorize transaction
+messages as well as delegating the voting authentication using _voting keys_, unless
+that specific account was rekeyed. A rekeyed account would use the rekeyed key in
+lieu of the root key.
 
 A relationship between a _root key_ and _voting keys_ is established when accounts
 _register_ their participation in the agreement protocol.

--- a/src/keys/keys-root.md
+++ b/src/keys/keys-root.md
@@ -3,8 +3,8 @@
 Root keys are used to identify ownership of an account. An Algorand node only
 interacts with the public part of a root key (public keys or program bytecode).
 
-Each account is controlled by a _root_ authorization method, which also binds the
-account address to the authorization material:
+An account is controlled by one of the following _root_ authorization methods, which
+also bind the account address to the authorization material:
 
 - A single [Ed25519](../crypto/crypto-ed25519.md) key pair. The public key of the
 root key is used directly as the account address;
@@ -17,10 +17,15 @@ version, the authorization threshold, and all the participating public keys;
 program, wholly in charge of a _contract account_. The account address is derived
 by hashing the program bytecode;
 
-- A post-quantum scheme key pair. The account address is derived by hashing the
-scheme identifier, an address salt, and the public key, as specified in the
-[Post-Quantum Signature](../ledger/ledger-txn-authorization.md#post-quantum-signature)
-section of the Ledger specification.
+- A [post-quantum scheme](../ledger/ledger-txn-authorization.md#post-quantum-signature)
+key pair. The account address is derived by hashing the scheme identifier, an address
+salt, and the public key.
+
+{{#include ../_include/styles.md:note}}
+> Application accounts are the exception: their address is the hash of the Application
+> ID (prefixed by `appID`), which binds no authorization material. No root key exists
+> for these accounts: they cannot authorize top-level transactions and, unless rekeyed,
+> are controlled exclusively by their Application through [inner transactions](../avm/avm-ops-inner-transactions.md).
 
 Regardless of the authorization method, root keys are used to authorize transaction
 messages as well as delegating the voting authentication using _voting keys_, unless

--- a/src/keys/keys-root.md
+++ b/src/keys/keys-root.md
@@ -24,13 +24,12 @@ salt, and the public key.
 {{#include ../_include/styles.md:note}}
 > Application accounts are the exception: their address is the hash of the Application
 > ID (prefixed by `appID`), which binds no authorization material. No root key exists
-> for these accounts: they cannot authorize top-level transactions and, unless rekeyed,
-> are controlled exclusively by their Application through [inner transactions](../avm/avm-ops-inner-transactions.md).
+> for these accounts: unless rekeyed, they are controlled exclusively by their
+> Application through [inner transactions](../avm/avm-ops-inner-transactions.md).
 
-Regardless of the authorization method, root keys are used to authorize transaction
-messages as well as delegating the voting authentication using _voting keys_, unless
-that specific account was rekeyed. A rekeyed account would use the rekeyed key in
-lieu of the root key.
+An account's root authorization method authorizes its transaction messages. If the
+account is rekeyed, the authorization method associated with its authorization address
+is used instead.
 
 A relationship between a _root key_ and _voting keys_ is established when accounts
 _register_ their participation in the agreement protocol.

--- a/src/keys/keys.md
+++ b/src/keys/keys.md
@@ -1,9 +1,11 @@
 # Algorand Keys Specification
 
-An Algorand node interacts with three types of cryptographic keys:
+An Algorand node interacts with three types of cryptographic material:
 
-- _Root keys_, a key pair (public and private) used to control the access to a particular
-account. These key pairs are also known as _Spending Keys_ (as they sign accounts’ transactions).
+- _Root keys_, the authorization material used to control the access to a particular
+account: a single key pair (such as Ed25519 or a post-quantum scheme), a multisignature
+composition of key pairs, or a logic signature program. Root keys are also known as
+_Spending Keys_ (as they authorize accounts’ transactions).
 
 - _Voting keys_, a set of keys used for authentication, i.e. identify an account
 in the Algorand Byzantine Fault Tolerant protocol (see [ABFT section](../abft/abft.md)).

--- a/src/keys/keys.md
+++ b/src/keys/keys.md
@@ -1,6 +1,6 @@
 # Algorand Keys Specification
 
-An Algorand node interacts with three types of cryptographic material:
+An Algorand node interacts with three types of cryptographic keys:
 
 - _Root keys_, the authorization material used to control the access to a particular
 account: a single key pair (such as Ed25519 or a post-quantum scheme), a multisignature

--- a/src/ledger/ledger-txn-authorization.md
+++ b/src/ledger/ledger-txn-authorization.md
@@ -129,6 +129,7 @@ The `pqsig` object contains the following fields:
 
 - The scheme identifier `sch`, a 2-byte string identifying the post-quantum signature
 scheme. The supported values are:
+
   - `f1`, denoting [deterministic FALCON-1024](../crypto/crypto-falcon.md).
 
 - The address salt `slt`, a 1-byte unsigned integer.

--- a/src/ledger/ledger-txn-authorization.md
+++ b/src/ledger/ledger-txn-authorization.md
@@ -3,8 +3,6 @@ $$
 \newcommand \pk {\mathrm{pk}}
 \newcommand \MSigPrefix {\texttt{MultisigAddr}}
 \newcommand \PQAPrefix {\texttt{PQA}}
-\newcommand \PQProgramPrefix {\texttt{PQProgram}}
-\newcommand \Tx {\mathrm{Tx}}
 \newcommand \Fee {\mathrm{fee}}
 \newcommand \MinTxnFee {T_{\Fee,\min}}
 $$
@@ -52,46 +50,39 @@ public key).
 which hashes to the _authorizer address_ as described in the [Multisignature](#multisignature)
 section:
 
-  - The `subsig` array of subsignatures, each consisting of a signer address and a
-  64-byte signature of the transaction. Note that transaction signed by a multisignature
-  account **MUST** contain all signer's addresses in the `subsig` array even if the
-  transaction has not been signed by that address.
+  - The `subsig` array of subsignatures, each consisting of a signer address and
+  a 64-byte signature of the message covered by the multisignature. The signature
+  **MUST** contain all signer's addresses in the `subsig` array even if the transaction
+  has not been signed by that address.
 
   - The threshold `thr` that is a minimum number of **REQUIRED** signatures.
 
   - The multisignature version `v` (current value is \\( 1 \\)).
 
+- A valid _post-quantum signature_ (`pqsig`) is an object which derives the _authorizer
+address_ and signs the transaction with a post-quantum signature scheme, as described
+in the [Post-Quantum Signature](#post-quantum-signature) section.
+
 - A valid _logic signature_ (`lsig`) is an object containing the following fields:
 
   - The logic `l` which is versioned bytecode (see [AVM specifications](../avm/avm.md)).
 
-  - An **OPTIONAL** single signature `sig` of 64-bytes valid from the authorizer
-  address of the transaction which has signed the string `Program` concatenated
-  with the bytes in `l`.
-
-  - An **OPTIONAL** multisignature `lmsig` from the authorizer address of the
-  transaction over the string `MsigProgram` concatenated with the bytes of the
-  authorizer address and the bytes in `l`.
-
-  - An **OPTIONAL** post-quantum signature `pqsig` from the authorizer address of
-  the transaction over the 32-byte hash of the string `PQProgram` concatenated
-  with the bytes of the authorizer address and the bytes in `l`, as described in
-  the [Logic Signature Delegation](#logic-signature-delegation) section.
+  - At most one **OPTIONAL** delegation signature: a single signature `sig`, a multisignature
+  `lmsig`, or a post-quantum signature `pqsig` from the authorizer address of the
+  transaction, as described in the [Logic Signature Delegation](#logic-signature-delegation)
+  section.
 
   - An **OPTIONAL** array of byte strings `arg` which are arguments supplied to the
   program in `l` (`arg` bytes are not covered by `sig`, `lmsig`, or `pqsig`).
 
-The logic signature is valid if exactly one of `sig`, `lmsig`, or `pqsig` is a valid
-signature of the program by the authorizer address of the transaction, or if none
-of them is set and the hash of the program is equal to the authorizer address.
+The logic signature is valid if the one set is a valid [delegation signature](#logic-signature-delegation)
+of the program by the authorizer address of the transaction, or if none of them is
+set and the authorizer address is equal to the program hash defined in the
+[Contract Account Mode](../avm/avm-mode-logic-signatures.md#contract-account-mode).
 
 Also the program **MUST** execute and finish with a single non-zero value on the
 AVM stack (see [AVM specifications](../avm/avm.md) for details on program execution
 semantics).
-
-A valid _post-quantum signature_ (`pqsig`) is an object which derives the _authorizer
-address_ and signs the transaction with a post-quantum signature scheme, as described
-in the [Post-Quantum Signature](#post-quantum-signature) section.
 
 ## Multisignature
 
@@ -121,7 +112,7 @@ In this case, every occurrence is counted independently in validation.
 
 The multisignature validation process checks that:
 
-1. All non-empty signatures are valid;
+1. All non-empty signatures are valid for the same message covered by the multisignature;
 
 1. The valid signatures count is not less than the threshold.
 
@@ -145,8 +136,7 @@ scheme. The supported values are:
 
 - The canonical public key `pk` of the scheme, a byte string.
 
-- The canonical signature `sig` of the scheme, a non-empty byte string. For scheme
-`f1`, it must be a FALCON-1024 signature in compressed format.
+- The canonical signature `sig` of the scheme, a non-empty byte string.
 
 The _post-quantum address_ of a scheme identifier, salt, and public key is derived
 by hashing their concatenation with the domain separation prefix \\( \PQAPrefix \\):
@@ -168,36 +158,9 @@ A post-quantum signature is valid if all the following conditions hold:
 1. The post-quantum address derived from `sch`, `slt`, and `pk` is equal to the
 _authorizer address_ of the transaction;
 
-1. The signature `sig` is valid for the message \\( \Hash(\Tx) \\), the 32-byte
-[transaction identifier](./ledger-transactions.md), under the public key `pk`,
-according to the scheme denoted by `sch`.
-
-> Note that, unlike `sig` and `msig`, which sign the domain-separated encoded
-> transaction, the message signed by a `f1` signature is the 32-byte _hash_ of the
-> domain-separated encoded transaction.
-
-### Logic Signature Delegation
-
-A post-quantum account **MAY** delegate a [logic signature](../avm/avm-mode-logic-signatures.md#delegated-signature-mode):
-the `lsig` object carries a `pqsig` object, as defined above, in place of an Ed25519
-signature or multisignature delegation.
-
-A post-quantum logic signature delegation is valid if all the following conditions
-hold:
-
-1. The scheme identifier `sch` is supported;
-
-1. The post-quantum address derived from `sch`, `slt`, and `pk` is equal to the
-_authorizer address_ of the transaction;
-
-1. The signature `sig` is valid for the message \\( \Hash(\PQProgramPrefix, A, \mathtt{l}) \\),
-the 32-byte hash of the _authorizer address_ \\( A \\) concatenated with the program
-bytecode `l` (with domain separation prefix \\( \PQProgramPrefix \\)), under the
-public key `pk`, according to the scheme denoted by `sch`.
-
-> The signed message binds the delegating account address: a delegation produced
-> for one account is not valid for any other account, in particular for a different
-> salted address derived from the same public key.
+1. The signature `sig` is valid for the transaction (encoded in canonical msgpack
+and with [domain separation prefix](../crypto/crypto-domain-separators.md) `TX`),
+under the public key `pk`, according to the scheme denoted by `sch`.
 
 ### Fee Surcharge
 
@@ -209,3 +172,29 @@ an additional fee, given by the scheme _fee contribution_:
 
 This contribution adds to the [minimum fee](./ledger-txn-groups.md) otherwise required
 by the transaction or by its transaction group, if any.
+
+## Logic Signature Delegation
+
+An account **MAY** delegate authority to a logic signature by signing its program
+(see the [Delegated Signature Mode](../avm/avm-mode-logic-signatures.md#delegated-signature-mode)
+of the AVM specifications).
+
+The `lsig` object carries the delegation signature in one of the following forms,
+according to the delegating account type:
+
+- The single signature `sig` is a valid 64-byte [Ed25519 signature](../crypto/crypto-ed25519.md)
+of the string `Program` concatenated with the bytes in `l`, where the public key
+is the _authorizer address_.
+
+- The multisignature `lmsig` is a valid multisignature (an object structured as
+`msig`), which hashes to the _authorizer address_ as described in the [Multisignature](#multisignature)
+section, where the covered message is the string `MsigProgram` concatenated with
+the bytes of the authorizer address and the bytes in `l`.
+
+- The post-quantum signature `pqsig` is a valid [post-quantum signature](#post-quantum-signature),
+where the signed message is the string `PQProgram` concatenated with the bytes of
+the authorizer address and the bytes in `l`, in place of the transaction.
+
+> The `lmsig` and `pqsig` messages bind the delegating account address: a delegation
+> produced for one account is not valid for any other account (in particular, for a
+> different salted address derived from the same post-quantum public key).

--- a/src/ledger/ledger-txn-authorization.md
+++ b/src/ledger/ledger-txn-authorization.md
@@ -66,20 +66,22 @@ section:
   - The logic `l` which is versioned bytecode (see [AVM specifications](../avm/avm.md)).
 
   - An **OPTIONAL** single signature `sig` of 64-bytes valid from the authorizer
-  address of the transaction which has signed the bytes in `l`.
+  address of the transaction which has signed the string `Program` concatenated
+  with the bytes in `l`.
 
-  - An **OPTIONAL** multisignature `lmsig` from the authorizer address of the transaction
-  over the bytes of the authorizer address and the bytes in `l`.
+  - An **OPTIONAL** multisignature `lmsig` from the authorizer address of the
+  transaction over the string `MsigProgram` concatenated with the bytes of the
+  authorizer address and the bytes in `l`.
 
   - An **OPTIONAL** post-quantum signature `pqsig` from the authorizer address of
-  the transaction over the bytes of the authorizer address and the bytes in `l`,
-  as described in the [Logic Signature Delegation](#logic-signature-delegation)
-  section.
+  the transaction over the 32-byte hash of the string `PQProgram` concatenated
+  with the bytes of the authorizer address and the bytes in `l`, as described in
+  the [Logic Signature Delegation](#logic-signature-delegation) section.
 
   - An **OPTIONAL** array of byte strings `arg` which are arguments supplied to the
-  program in `l` (`arg` bytes are not covered by `sig`, `msig`, or `pqsig`).
+  program in `l` (`arg` bytes are not covered by `sig`, `lmsig`, or `pqsig`).
 
-The logic signature is valid if exactly one of `sig`, `msig`, or `pqsig` is a valid
+The logic signature is valid if exactly one of `sig`, `lmsig`, or `pqsig` is a valid
 signature of the program by the authorizer address of the transaction, or if none
 of them is set and the hash of the program is equal to the authorizer address.
 

--- a/src/ledger/ledger-txn-authorization.md
+++ b/src/ledger/ledger-txn-authorization.md
@@ -166,12 +166,15 @@ under the public key `pk`, according to the scheme denoted by `sch`.
 
 A transaction authorized with a post-quantum signature, either directly or through
 a [post-quantum delegated logic signature](#logic-signature-delegation), requires
-an additional fee, given by the scheme _fee contribution_:
+an additional fee, given by the _scheme fee contribution_:
 
 - `f1`: \\( 2 \times \MinTxnFee \\).
 
 This contribution adds to the [minimum fee](./ledger-txn-groups.md) otherwise required
-by the transaction or by its transaction group, if any.
+by the transaction or by its transaction group, if any. The contribution adds even
+when the minimum fee is discounted in a fee-exempt Heartbeat transaction authorized
+by a post-quantum signature. The contribution never applies to a State Proof transaction,
+since it carries no authorization at all.
 
 ## Logic Signature Delegation
 

--- a/src/ledger/ledger-txn-authorization.md
+++ b/src/ledger/ledger-txn-authorization.md
@@ -3,6 +3,7 @@ $$
 \newcommand \pk {\mathrm{pk}}
 \newcommand \MSigPrefix {\texttt{MultisigAddr}}
 \newcommand \PQAPrefix {\texttt{PQA}}
+\newcommand \PQProgramPrefix {\texttt{PQProgram}}
 \newcommand \Tx {\mathrm{Tx}}
 \newcommand \Fee {\mathrm{fee}}
 \newcommand \MinTxnFee {T_{\Fee,\min}}
@@ -70,12 +71,17 @@ section:
   - An **OPTIONAL** multisignature `lmsig` from the authorizer address of the transaction
   over the bytes of the authorizer address and the bytes in `l`.
 
-  - An **OPTIONAL** array of byte strings `arg` which are arguments supplied to the
-  program in `l` (`arg` bytes are not covered by `sig` or `msig`).
+  - An **OPTIONAL** post-quantum signature `pqsig` from the authorizer address of
+  the transaction over the bytes of the authorizer address and the bytes in `l`,
+  as described in the [Logic Signature Delegation](#logic-signature-delegation)
+  section.
 
-The logic signature is valid if exactly one of `sig` or `msig` is a valid signature
-of the program by the authorizer address of the transaction, or if neither `sig`
-nor `msig` is set and the hash of the program is equal to the authorizer address.
+  - An **OPTIONAL** array of byte strings `arg` which are arguments supplied to the
+  program in `l` (`arg` bytes are not covered by `sig`, `msig`, or `pqsig`).
+
+The logic signature is valid if exactly one of `sig`, `msig`, or `pqsig` is a valid
+signature of the program by the authorizer address of the transaction, or if none
+of them is set and the hash of the program is equal to the authorizer address.
 
 Also the program **MUST** execute and finish with a single non-zero value on the
 AVM stack (see [AVM specifications](../avm/avm.md) for details on program execution
@@ -123,7 +129,8 @@ correct signatures is greater or equals than the threshold.
 ## Post-Quantum Signature
 
 A post-quantum signature authorizes a transaction with a post-quantum digital signature
-scheme.
+scheme, either directly (`SignedTxn` field `pqsig`) or by delegating a logic signature
+(`lsig` field `pqsig`, see [Logic Signature Delegation](#logic-signature-delegation)).
 
 The `pqsig` object contains the following fields:
 
@@ -167,13 +174,36 @@ according to the scheme denoted by `sch`.
 > transaction, the message signed by a `f1` signature is the 32-byte _hash_ of the
 > domain-separated encoded transaction.
 
+### Logic Signature Delegation
+
+A post-quantum account **MAY** delegate a [logic signature](../avm/avm-mode-logic-signatures.md#delegated-signature-mode):
+the `lsig` object carries a `pqsig` object, as defined above, in place of an Ed25519
+signature or multisignature delegation.
+
+A post-quantum logic signature delegation is valid if all the following conditions
+hold:
+
+1. The scheme identifier `sch` is supported;
+
+1. The post-quantum address derived from `sch`, `slt`, and `pk` is equal to the
+_authorizer address_ of the transaction;
+
+1. The signature `sig` is valid for the message \\( \Hash(\PQProgramPrefix, A, \mathtt{l}) \\),
+the 32-byte hash of the _authorizer address_ \\( A \\) concatenated with the program
+bytecode `l` (with domain separation prefix \\( \PQProgramPrefix \\)), under the
+public key `pk`, according to the scheme denoted by `sch`.
+
+> The signed message binds the delegating account address: a delegation produced
+> for one account is not valid for any other account, in particular for a different
+> salted address derived from the same public key.
+
 ### Fee Surcharge
 
-A transaction authorized with a post-quantum signature requires an additional fee,
-given by the scheme _fee contribution_:
+A transaction authorized with a post-quantum signature, either directly or through
+a [post-quantum delegated logic signature](#logic-signature-delegation), requires
+an additional fee, given by the scheme _fee contribution_:
 
 - `f1`: \\( 2 \times \MinTxnFee \\).
 
 This contribution adds to the [minimum fee](./ledger-txn-groups.md) otherwise required
-by the transaction or by its transaction group, if any. Zero-fee heartbeat transactions
-with a zero _group_ field are exempt from the fee contribution.
+by the transaction or by its transaction group, if any.

--- a/src/ledger/ledger-txn-authorization.md
+++ b/src/ledger/ledger-txn-authorization.md
@@ -2,6 +2,10 @@ $$
 \newcommand \Hash {\mathrm{Hash}}
 \newcommand \pk {\mathrm{pk}}
 \newcommand \MSigPrefix {\texttt{MultisigAddr}}
+\newcommand \PQAPrefix {\texttt{PQA}}
+\newcommand \Tx {\mathrm{Tx}}
+\newcommand \Fee {\mathrm{fee}}
+\newcommand \MinTxnFee {T_{\Fee,\min}}
 $$
 
 # Authorization and Signatures
@@ -22,11 +26,11 @@ The `SignedTxn` struct contains:
 
 - An **OPTIONAL** _authorizer address_ (field `sgnr`);
 
-- Exactly one of a _signature_ (field `sig`), _multisignature_ (field `msig`), or
-_logic signature_ (field `lsig`).
+- Exactly one of a _signature_ (field `sig`), _multisignature_ (field `msig`),
+_logic signature_ (field `lsig`), or _post-quantum signature_ (field `pqsig`).
 
 The _authorizer address_, a 32-byte address, determines against what to verify the
-`sig` / `msig` / `lsig`, as described below.
+`sig` / `msig` / `lsig` / `pqsig`, as described below.
 
 If the `sgnr` field is omitted (or zero), then the _authorizer address_ defaults
 to the transaction _sender_ address.
@@ -77,6 +81,10 @@ Also the program **MUST** execute and finish with a single non-zero value on the
 AVM stack (see [AVM specifications](../avm/avm.md) for details on program execution
 semantics).
 
+A valid _post-quantum signature_ (`pqsig`) is an object which derives the _authorizer
+address_ and signs the transaction with a post-quantum signature scheme, as described
+in the [Post-Quantum Signature](#post-quantum-signature) section.
+
 ## Multisignature
 
 Multisignature term describes a special multisignature address, signing and validation
@@ -111,3 +119,60 @@ The multisignature validation process checks that:
 
 Validation fails if any of the signatures is invalid, even if the count of all remaining
 correct signatures is greater or equals than the threshold.
+
+## Post-Quantum Signature
+
+A post-quantum signature authorizes a transaction with a post-quantum digital signature
+scheme.
+
+The `pqsig` object contains the following fields:
+
+- The scheme identifier `sch`, a 2-byte string identifying the post-quantum signature
+scheme. The supported values are:
+  - `f1`, denoting [deterministic FALCON-1024](../crypto/crypto-falcon.md).
+
+- The address salt `slt`, a 1-byte unsigned integer.
+
+- The canonical public key `pk` of the scheme, a byte string.
+
+- The canonical signature `sig` of the scheme, a non-empty byte string. For scheme
+`f1`, it must be a FALCON-1024 signature in compressed format.
+
+The _post-quantum address_ of a scheme identifier, salt, and public key is derived
+by hashing their concatenation with the domain separation prefix \\( \PQAPrefix \\):
+
+$$
+\mathrm{PQAddr} = \Hash(\PQAPrefix, \mathtt{sch}, \mathtt{slt}, \pk)
+$$
+
+> The salt takes part in the address derivation, so one public key derives up to
+> \\( 256 \\) distinct addresses. This allows clients to select, by rejection sampling
+> over the salt, an address which is not a valid Ed25519 public key, so that no
+> Ed25519 signature may ever authorize the account. This property is not enforced
+> by consensus.
+
+A post-quantum signature is valid if all the following conditions hold:
+
+1. The scheme identifier `sch` is supported;
+
+1. The post-quantum address derived from `sch`, `slt`, and `pk` is equal to the
+_authorizer address_ of the transaction;
+
+1. The signature `sig` is valid for the message \\( \Hash(\Tx) \\), the 32-byte
+[transaction identifier](./ledger-transactions.md), under the public key `pk`,
+according to the scheme denoted by `sch`.
+
+> Note that, unlike `sig` and `msig`, which sign the domain-separated encoded
+> transaction, the message signed by a `f1` signature is the 32-byte _hash_ of the
+> domain-separated encoded transaction.
+
+### Fee Surcharge
+
+A transaction authorized with a post-quantum signature requires an additional fee,
+given by the scheme _fee contribution_:
+
+- `f1`: \\( 2 \times \MinTxnFee \\).
+
+This contribution adds to the [minimum fee](./ledger-txn-groups.md) otherwise required
+by the transaction or by its transaction group, if any. Zero-fee heartbeat transactions
+with a zero _group_ field are exempt from the fee contribution.

--- a/src/ledger/ledger-txn-authorization.md
+++ b/src/ledger/ledger-txn-authorization.md
@@ -138,9 +138,11 @@ scheme. The supported values are:
 
 - The address salt `slt`, a 1-byte unsigned integer.
 
-- The canonical public key `pk` of the scheme, a byte string.
+- The canonical public key `pk` of the scheme, a byte string whose length **MUST**
+be the public key size defined by the scheme.
 
-- The canonical signature `sig` of the scheme, a non-empty byte string.
+- The canonical signature `sig` of the scheme, a non-empty byte string whose length
+**MUST NOT** exceed the maximum signature size defined by the scheme.
 
 The _post-quantum address_ of a scheme identifier, salt, and public key is derived
 by hashing their concatenation with the domain separation prefix \\( \PQAPrefix \\):

--- a/src/ledger/ledger-txn-authorization.md
+++ b/src/ledger/ledger-txn-authorization.md
@@ -73,7 +73,11 @@ in the [Post-Quantum Signature](#post-quantum-signature) section.
   section.
 
   - An **OPTIONAL** array of byte strings `arg` which are arguments supplied to the
-  program in `l` (`arg` bytes are not covered by `sig`, `lmsig`, or `pqsig`).
+  program in `l` (`arg` bytes are not covered by `sig`, `lmsig`, or `pqsig`). The
+  array **MUST NOT** contain more than \\( 255 \\) elements and each element
+  **MUST NOT** exceed \\( 4096 \\) bytes. The combined length of the program and
+  its arguments is further limited, as described in the [Bytecode Size](../avm/avm-mode-logic-signatures.md#bytecode-size)
+  section of the AVM specifications.
 
 The logic signature is valid if the one set is a valid [delegation signature](#logic-signature-delegation)
 of the program by the authorizer address of the transaction, or if none of them is
@@ -173,7 +177,7 @@ an additional fee, given by the _scheme fee contribution_:
 This contribution adds to the [minimum fee](./ledger-txn-groups.md) otherwise required
 by the transaction or by its transaction group, if any. The contribution adds even
 when the minimum fee is discounted in a fee-exempt Heartbeat transaction authorized
-by a post-quantum signature. The contribution never applies to a State Proof transaction,
+by a post-quantum signature. The contribution never applies to a [State Proof transaction](./ledger-txn-state-proof.md#validation),
 since it carries no authorization at all.
 
 ## Logic Signature Delegation

--- a/src/ledger/ledger-txn-groups.md
+++ b/src/ledger/ledger-txn-groups.md
@@ -77,10 +77,9 @@ ago, and has not proposed or heartbeat since that challenge.
 > Further explanation of this rule is found in [Heartbeat transaction semantics](./ledger-txn-semantics-heartbeat.md)
 > section.
 
-Additionally, each transaction authorized with a [post-quantum signature](./ledger-txn-authorization.md#post-quantum-signature)
-raises the minimum fee requirement of its group by the scheme _fee contribution_,
-with the exception of zero-fee heartbeat transactions with a zero _group_ field
-(see [Fee Surcharge](./ledger-txn-authorization.md#fee-surcharge)).
+Additionally, each transaction authorized with a [post-quantum signature](./ledger-txn-authorization.md#post-quantum-signature),
+directly or through a delegated logic signature, raises the minimum fee requirement
+of its group by the scheme _fee contribution_.
 
 If the sum of the lengths of the boxes denoted by the box references in a transaction
 group exceeds \\( \BytesPerBoxReference \\) times the total number of box references

--- a/src/ledger/ledger-txn-groups.md
+++ b/src/ledger/ledger-txn-groups.md
@@ -77,10 +77,10 @@ ago, and has not proposed or heartbeat since that challenge.
 > Further explanation of this rule is found in [Heartbeat transaction semantics](./ledger-txn-semantics-heartbeat.md)
 > section.
 
-Additionally, each transaction authorized with a
-[post-quantum signature](./ledger-txn-authorization.md#post-quantum-signature)
+Additionally, each transaction authorized with a [post-quantum signature](./ledger-txn-authorization.md#post-quantum-signature)
 raises the minimum fee requirement of its group by the scheme _fee contribution_,
-with the exception of zero-fee heartbeat transactions with a zero _group_ field.
+with the exception of zero-fee heartbeat transactions with a zero _group_ field
+(see [Fee Surcharge](./ledger-txn-authorization.md#fee-surcharge)).
 
 If the sum of the lengths of the boxes denoted by the box references in a transaction
 group exceeds \\( \BytesPerBoxReference \\) times the total number of box references

--- a/src/ledger/ledger-txn-groups.md
+++ b/src/ledger/ledger-txn-groups.md
@@ -77,6 +77,11 @@ ago, and has not proposed or heartbeat since that challenge.
 > Further explanation of this rule is found in [Heartbeat transaction semantics](./ledger-txn-semantics-heartbeat.md)
 > section.
 
+Additionally, each transaction authorized with a
+[post-quantum signature](./ledger-txn-authorization.md#post-quantum-signature)
+raises the minimum fee requirement of its group by the scheme _fee contribution_,
+with the exception of zero-fee heartbeat transactions with a zero _group_ field.
+
 If the sum of the lengths of the boxes denoted by the box references in a transaction
 group exceeds \\( \BytesPerBoxReference \\) times the total number of box references
 in the transaction group, then the block is invalid. Call this limit the _I/O Budget_

--- a/src/ledger/ledger-txn-groups.md
+++ b/src/ledger/ledger-txn-groups.md
@@ -79,7 +79,7 @@ ago, and has not proposed or heartbeat since that challenge.
 
 Additionally, each transaction authorized with a [post-quantum signature](./ledger-txn-authorization.md#post-quantum-signature),
 directly or through a delegated logic signature, raises the minimum fee requirement
-of its group by the scheme _fee contribution_.
+of its group by the scheme _fee contribution_ (see [Fee Surcharge](./ledger-txn-authorization.md#fee-surcharge)).
 
 If the sum of the lengths of the boxes denoted by the box references in a transaction
 group exceeds \\( \BytesPerBoxReference \\) times the total number of box references

--- a/src/ledger/ledger-txn-groups.md
+++ b/src/ledger/ledger-txn-groups.md
@@ -65,7 +65,7 @@ Additionally, if a block contains a transaction group of more than \\( \MaxTxGro
 transactions, the block is invalid.
 
 If the sum of the fees paid by the \\( n \\) transactions in a transaction group
-is less than \\( n \times \MinTxnFee )\\, then the block is invalid. There are two
+is less than \\( n \times \MinTxnFee \\), then the block is invalid. There are two
 exceptions to this fee requirement:
 
 1. State Proof transactions require no fee;


### PR DESCRIPTION
This PR updates the specs with post quantum signatures, it adds:

- Domain separators in `crypto`
- New `pqsig` authorization in `ledger`
- Usage of `pqsig` for Lsig delegation
- Usage of `pqsig` as root key in `keys`
- `pqsig` fee surcharge
- Falcon: removed 48 bytes seed requirement, added signature compressed format

Bonus:

- Updated `keys` to include missing `msig` and `lsig` root key types
- Added a new dedicated Logic Signature Delegation section in Ledger to split messages and validity in the ledger from execution and mode concepts (AVM).