### PR TITLE
Ledger: consolidate minimum balance requirement discussion

### DIFF
--- a/src/avm/avm-ops-state-access.md
+++ b/src/avm/avm-ops-state-access.md
@@ -18,11 +18,13 @@
 
 ## Box Access
 
-Box opcodes that create, delete, or resize boxes affect the minimum
-balance requirement of the calling application's account.  The change
-is immediate, and can be observed after exection by using
-`min_balance`.  If the account does not possess the new minimum
-balance, the opcode fails.
+Box opcodes that create, delete, or resize boxes affect the [minimum
+balance requirement](../ledger/ledger-account-state.md#minimum-balance-requirement)
+of the calling application's account.  The change is immediate, and can
+be observed after execution by using `min_balance`.  The requirement
+itself is enforced for the transaction as a whole, as described in the
+Ledger's [account state validity
+conditions](../ledger/ledger-validation.md).
 
 All box related opcodes fail immediately if used in a
 ClearStateProgram. This behavior is meant to discourage Smart Contract

--- a/src/ledger/ledger-account-state.md
+++ b/src/ledger/ledger-account-state.md
@@ -6,6 +6,20 @@ $$
 \newcommand \Units {\mathrm{Units}}
 $$
 
+$$
+\newcommand \MBR {\mathrm{MBR}}
+\newcommand \MinBalance {b_{\min}}
+\newcommand \App {\mathrm{App}}
+\newcommand \AppFlatOptInMinBalance {\App_{\mathrm{optin},\MinBalance}}
+\newcommand \AppFlatParamsMinBalance {\App_{\mathrm{create},\MinBalance}}
+\newcommand \SchemaBytesMinBalance {\App_{\mathrm{b},\MinBalance}}
+\newcommand \SchemaMinBalancePerEntry {\App_{\mathrm{s},\MinBalance}}
+\newcommand \SchemaUintMinBalance {\App_{\mathrm{u},\MinBalance}}
+\newcommand \Box {\mathrm{Box}}
+\newcommand \BoxByteMinBalance {\Box_{\mathrm{byte},\MinBalance}}
+\newcommand \BoxFlatMinBalance {\Box_{\mathrm{flat},\MinBalance}}
+$$
+
 # Account State
 
 The _balances_ are a set of mappings from _addresses_, 256-bit integers, to _balance
@@ -100,3 +114,52 @@ There exist two special addresses:
 - \\( I_f \\), the address of the _fee sink_.
 
 For both of these accounts, \\( p_I = 2 \\).
+
+## Minimum Balance Requirement
+
+Every account has a _minimum balance requirement_ (MBR), the amount of μALGO it must
+hold in order to occupy the space it uses in the Ledger. The MBR of an account \\( I \\)
+in the intermediate state \\( \rho \\), \\( \MBR(\rho, I) \\), is \\( \MinBalance \\)
+plus a contribution for each resource the account is responsible for:
+
+<!-- markdownlint-disable MD013 -->
+$$
+\begin{aligned}
+\MBR(\rho, I) = \; & \MinBalance \times (1 + N_A) \\
+                   & + \AppFlatParamsMinBalance \times (N_C + N_P)
+                     + \AppFlatOptInMinBalance \times N_O \\
+                   & + (\SchemaMinBalancePerEntry + \SchemaUintMinBalance) \times \mathrm{NumUint} \\
+                   & + (\SchemaMinBalancePerEntry + \SchemaBytesMinBalance) \times \mathrm{NumByteSlice} \\
+                   & + \BoxFlatMinBalance \times N_B + \BoxByteMinBalance \times S_B
+\end{aligned}
+$$
+<!-- markdownlint-enable MD013 -->
+
+where, for the account \\( I \\) in the intermediate state \\( \rho \\):
+
+- \\( N_A \\) is the number of [assets](./ledger-assets.md#asset-minimum-balance-contribution)
+it holds, whether created by it or opted in to,
+
+- \\( N_C \\) is the number of [applications](./ledger-applications.md#app-minimum-balance-contributions)
+it created and \\( N_O \\) is the number of applications it is opted in to,
+
+- \\( N_P \\) is the total `ExtraProgramPages` of the applications whose sizes it
+[sponsors](./ledger-applications.md#size-sponsor),
+
+- \\( \mathrm{NumUint} \\) and \\( \mathrm{NumByteSlice} \\) are the summed
+[state schema](./ledger-applications.md#state-schemas) entry counts of the
+`LocalStateSchema` of each application it is opted in to and of the `GlobalStateSchema`
+of each application whose size it sponsors,
+
+- \\( N_B \\) is the number of [boxes](./ledger-applications.md#boxes) held by the
+application whose account address is \\( I \\), and \\( S_B \\) is their total size in
+bytes, counting each box’s name and contents.
+
+The sections describing those resources specify when each contribution is incurred and
+released. A contribution takes effect as soon as the state it accounts for is allocated,
+so an MBR increase is visible to a program that allocates state (through the AVM
+`min_balance` opcode) before that program completes.
+
+The requirement itself is enforced after each transaction, for every account, as one of
+the [account state validity conditions](./ledger-validation.md). No transaction type
+imposes an MBR check of its own.

--- a/src/ledger/ledger-account-state.md
+++ b/src/ledger/ledger-account-state.md
@@ -125,12 +125,12 @@ plus a contribution for each resource the account is responsible for:
 <!-- markdownlint-disable MD013 -->
 $$
 \begin{aligned}
-\MBR(\rho, I) = \; & \MinBalance \times (1 + N_A) \\
-                   & + \AppFlatParamsMinBalance \times (N_C + N_P)
-                     + \AppFlatOptInMinBalance \times N_O \\
-                   & + (\SchemaMinBalancePerEntry + \SchemaUintMinBalance) \times \mathrm{NumUint} \\
-                   & + (\SchemaMinBalancePerEntry + \SchemaBytesMinBalance) \times \mathrm{NumByteSlice} \\
-                   & + \BoxFlatMinBalance \times N_B + \BoxByteMinBalance \times S_B
+\MBR(\rho, I) = & \MinBalance \times (1 + N_A) \\\\
+& + \AppFlatParamsMinBalance \times (N_C + N_P) \\\\
+& + \AppFlatOptInMinBalance \times N_O \\\\
+& + (\SchemaMinBalancePerEntry + \SchemaUintMinBalance) \times \mathrm{NumUint} \\\\
+& + (\SchemaMinBalancePerEntry + \SchemaBytesMinBalance) \times \mathrm{NumByteSlice} \\\\
+& + \BoxFlatMinBalance \times N_B + \BoxByteMinBalance \times S_B
 \end{aligned}
 $$
 <!-- markdownlint-enable MD013 -->

--- a/src/ledger/ledger-account-state.md
+++ b/src/ledger/ledger-account-state.md
@@ -144,7 +144,8 @@ it holds, whether created by it or opted in to,
 it created and \\( N_O \\) is the number of applications it is opted in to,
 
 - \\( N_P \\) is the total `ExtraProgramPages` of the applications whose sizes it
-[sponsors](./ledger-applications.md#size-sponsor),
+[sponsors](./ledger-applications.md#size-sponsor) — an application’s creator sponsors its
+size until another account sets it,
 
 - \\( \mathrm{NumUint} \\) and \\( \mathrm{NumByteSlice} \\) are the summed
 [state schema](./ledger-applications.md#state-schemas) entry counts of the

--- a/src/ledger/ledger-applications.md
+++ b/src/ledger/ledger-applications.md
@@ -107,9 +107,10 @@ field `fba`.
 Both box-access flags are initially false and may be changed by the application
 using `app_params_set`.
 
-Creating an application, opting in to one, and storing data in boxes all contribute to
-the [minimum balance requirement](./ledger-account-state.md#minimum-balance-requirement)
-of an account. The amounts are given in [App Minimum Balance
+Creating an application, [sponsoring](#size-sponsor) its size, opting in to one, and
+storing data in boxes all contribute to the [minimum balance
+requirement](./ledger-account-state.md#minimum-balance-requirement) of an account. The
+amounts are given in [App Minimum Balance
 Contributions](#app-minimum-balance-contributions) and [Boxes](#boxes).
 
 ## Key/Value Stores
@@ -145,10 +146,12 @@ requirement](./ledger-account-state.md#minimum-balance-requirement) of the accou
 are responsible for its state, in μALGO, as follows:
 
 - Its creator contributes \\( \AppFlatParamsMinBalance \\) for the application itself.
+This contribution always remains with the creator.
 
-- Its [size sponsor](#size-sponsor) contributes
-\\( \AppFlatParamsMinBalance \times \ExtraProgramPages \\) for the application’s extra
-program pages, plus the schema contribution below for its `GlobalStateSchema`.
+- Its [size sponsor](#size-sponsor), which is its creator until an update moves that
+responsibility, contributes \\( \AppFlatParamsMinBalance \times \ExtraProgramPages \\)
+for the application’s extra program pages, plus the schema contribution below for its
+`GlobalStateSchema`.
 
 - Each account opted in contributes \\( \AppFlatOptInMinBalance \\), plus the schema
 contribution below for the application’s `LocalStateSchema`.

--- a/src/ledger/ledger-applications.md
+++ b/src/ledger/ledger-applications.md
@@ -106,16 +106,11 @@ field `fba`.
 
 Both box-access flags are initially false and may be changed by the application
 using `app_params_set`.
-Each application created increases the minimum balance requirement of the creator
-by \\( \AppFlatParamsMinBalance \times (1+\ExtraProgramPages) \\) μALGO, plus the
-[`GlobalStateSchema` minimum balance contribution](#app-minimum-balance-changes).
-When a later [application update](./ledger-txn-semantics-application.md#step-6) changes
-these sizes, the portion of the requirement attributable to `ExtraProgramPages` and
-`GlobalStateSchema` moves to the application’s [size sponsor](#size-sponsor).
 
-Each application opted in to increases the minimum balance requirements of the opting-in
-account by \\( \AppFlatOptInMinBalance \\) μALGO plus the [`LocalStateSchema` minimum
-balance contribution](#app-minimum-balance-changes).
+Creating an application, opting in to one, and storing data in boxes all contribute to
+the [minimum balance requirement](./ledger-account-state.md#minimum-balance-requirement)
+of an account. The amounts are given in [App Minimum Balance
+Contributions](#app-minimum-balance-contributions) and [Boxes](#boxes).
 
 ## Key/Value Stores
 
@@ -143,34 +138,32 @@ some KV.
 - `NumByteSlice` represents the maximum number of _byte-array values_ that may appear
 in some KV.
 
-## App Minimum Balance Changes
+## App Minimum Balance Contributions
 
-When an account opts in to an application or creates an application, the minimum
-balance requirements for that account increases. The minimum balance requirement
-is decreased equivalently when an account closes out or deletes an app.
+An application contributes to the [minimum balance
+requirement](./ledger-account-state.md#minimum-balance-requirement) of the accounts that
+are responsible for its state, in μALGO, as follows:
 
-When opting in to an application, there is a base minimum balance increase of
-\\( \AppFlatOptInMinBalance \\) μALGO. There is an additional minimum balance increase,
-in μALGO, based on the `LocalStateSchema` for that application, described by the
-following formula:
+- Its creator contributes \\( \AppFlatParamsMinBalance \\) for the application itself.
 
-<!-- markdownlint-disable MD013 -->
-$$
-(\SchemaMinBalancePerEntry + \SchemaUintMinBalance) \times \mathrm{NumUint} + (\SchemaMinBalancePerEntry + \SchemaBytesMinBalance) \times \mathrm{NumByteSlice}
-$$
-<!-- markdownlint-enable MD013 -->
+- Its [size sponsor](#size-sponsor) contributes
+\\( \AppFlatParamsMinBalance \times \ExtraProgramPages \\) for the application’s extra
+program pages, plus the schema contribution below for its `GlobalStateSchema`.
 
-When creating an application, there is a base minimum balance increase of
-\\( \AppFlatParamsMinBalance \\) μALGO. There is an additional minimum balance increase
-of \\( \AppFlatParamsMinBalance \times \ExtraProgramPages \\) μALGO. Finally,
-there is an additional minimum balance increase, in μALGO, based on the `GlobalStateSchema`
-for that application, described by the following formula:
+- Each account opted in contributes \\( \AppFlatOptInMinBalance \\), plus the schema
+contribution below for the application’s `LocalStateSchema`.
+
+The contribution for a [state schema](#state-schemas) is:
 
 <!-- markdownlint-disable MD013 -->
 $$
 (\SchemaMinBalancePerEntry + \SchemaUintMinBalance) \times \mathrm{NumUint} + (\SchemaMinBalancePerEntry + \SchemaBytesMinBalance) \times \mathrm{NumByteSlice}
 $$
 <!-- markdownlint-enable MD013 -->
+
+Each contribution is released when the state it accounts for is released: deleting the
+application releases the creator’s and the size sponsor’s contributions, and closing out
+or clearing local state releases the contributions of the account that was opted in.
 
 ## Size Sponsor
 
@@ -193,10 +186,6 @@ to the account that submitted the update (the transaction’s _sender_), which b
 the new size sponsor. `SizeSponsor` is set to that account, except that when the sender
 is the creator, `SizeSponsor` is reset to zero.
 
-As with any transaction, the update **FAILS** unless the resulting balances still
-satisfy every affected account’s minimum balance requirement; in particular the sender
-must be able to cover the contributions it takes on.
-
 When the application is deleted, the contributions for its `ExtraProgramPages` and
 `GlobalStateSchema` are released from the current size sponsor.
 
@@ -214,13 +203,13 @@ of Boxes whose Application ID is not known at transaction group construction tim
 
 - The _value_ is a byte-array of length not greater than \\( \MaxBoxSize \\).
 
-When an application executes an opcode that creates, resizes, or destroys a box,
-the minimum balance of the associated application account (whose address is the hash
-of the application ID) is modified.
-
-When a box with name \\( n \\) and size \\( s \\) is created, the minimum balance
-requirement is raised by \\( \BoxFlatMinBalance + \BoxByteMinBalance \times (\mathrm{len}(n) + s) \\).
-The same amount is decremented from the minimum balance when the box is destroyed.
+Boxes are held by the application’s account, whose address is the hash of the application
+ID. A box with name \\( n \\) and size \\( s \\) contributes
+\\( \BoxFlatMinBalance + \BoxByteMinBalance \times (\mathrm{len}(n) + s) \\) μALGO to
+that account’s [minimum balance
+requirement](./ledger-account-state.md#minimum-balance-requirement) for as long as the
+box exists. An opcode that creates, resizes, or destroys a box changes the contribution
+immediately.
 
 ## Family Reentrancy
 

--- a/src/ledger/ledger-assets.md
+++ b/src/ledger/ledger-assets.md
@@ -75,14 +75,10 @@ if the holding is frozen or unfrozen.
 
 An account that holds any asset cannot be closed.
 
-## Asset Minimum Balance Changes
+## Asset Minimum Balance Contribution
 
-When an account opts in to an asset or creates an asset, the minimum balance requirements
-for that account increases. The minimum balance requirement is decreased equivalently
-when an account closes out or deletes an asset.
-
-When opting in to an asset, there is a base minimum balance increase of
-\\( \MinBalance \\) μALGO.
-
-When creating an asset, there is a base minimum balance increase of
-\\( \MinBalance \\) μALGO.
+Each asset holding of an account, whether allocated by creating the asset or by opting
+in to it, contributes \\( \MinBalance \\) μALGO to that account’s [minimum balance
+requirement](./ledger-account-state.md#minimum-balance-requirement). The contribution is
+released when the holding is deallocated, whether by closing out the holding or by
+destroying the asset.

--- a/src/ledger/ledger-txn-semantics-asset.md
+++ b/src/ledger/ledger-txn-semantics-asset.md
@@ -1,7 +1,3 @@
-$$
-\newcommand \MinBalance {b_{\min}}
-$$
-
 # Asset Transaction Semantics
 
 ## Asset Configuration
@@ -108,9 +104,6 @@ flag value from the freeze transaction.
 
 ## Asset Allocation
 
-When an asset transaction allocates space in an account for an asset, whether by
-creation or opt-in, the sender’s minimum balance requirement is incremented by
-\\( \MinBalance \\).
-
-When the space is deallocated, whether by asset destruction or asset close-to, the
-minimum balance requirement of the sender is decremented by \\( \MinBalance \\).
+Allocating and deallocating space for an asset holding changes the account’s minimum
+balance requirement, as described in [Asset Minimum Balance
+Contribution](./ledger-assets.md#asset-minimum-balance-contribution).

--- a/src/ledger/ledger-validation.md
+++ b/src/ledger/ledger-validation.md
@@ -24,7 +24,8 @@ $$
 \newcommand \PayoutsGoOnlineFee {B_{p,\Fee}}
 \newcommand \Eligibility {\mathrm{A_e}}
 \newcommand \Units {\mathrm{Units}}
-\newcommand \MinBalance {b_{\min}}
+\newcommand \MBR {\mathrm{MBR}}
+\newcommand \MaximumMinimumBalance {\mathrm{MBR}_{\max}}
 $$
 
 # Validity and State Changes
@@ -159,7 +160,28 @@ An account state in the intermediate state \\( \rho+1 \\) and at round \\( r \\)
 is valid if all following conditions hold:
 
 - For all addresses \\( I \notin \\{I_\mathrm{pool}, I_f\\} \\), either \\( \Stake(\rho+1, I) = 0 \\)
-or \\( \Stake(\rho+1, I) \geq \MinBalance \times (1 + N_A) \\), where \\( N_A \\)
-is the number of assets held by that account.
+or \\( \Stake(\rho+1, I) \geq \MBR(\rho+1, I) \\), where \\( \MBR(\rho+1, I) \\) is the
+account’s [minimum balance requirement](./ledger-account-state.md#minimum-balance-requirement).
+
+- For all addresses \\( I \notin \\{I_\mathrm{pool}, I_f\\} \\), if
+\\( \MaximumMinimumBalance \neq 0 \\), then \\( \MBR(\rho+1, I) \leq \MaximumMinimumBalance \\).
 
 - \\( \sum_I \Stake(\rho+1, I) = \sum_I \Stake(\rho, I) \\).
+
+These two minimum balance conditions are the only requirements the Ledger places on an
+account’s balance relative to its minimum balance requirement, and they apply to every
+transaction type. A transaction whose effects would leave any account in an invalid
+account state **FAILS**, and its effects are discarded.
+
+Because the conditions hold over all addresses, they constrain every account a transaction
+affects, not only its sender: for example, the receiver of a payment, an application
+account that creates a [box](./ledger-applications.md#boxes), and the account that becomes
+an application’s [size sponsor](./ledger-applications.md#size-sponsor) by taking on the
+contributions for that application’s size.
+
+Because the conditions constrain the intermediate state produced by each transaction,
+contributions incurred and released while a single transaction is evaluated — including by
+its inner transactions and by AVM box operations — are netted before the conditions are
+checked. Conversely, an account **MUST** satisfy its requirement at every intermediate
+state, so a [group](./ledger-txn-groups.md) may not leave an account below its requirement
+after one transaction even if a later transaction in the same group would restore it.


### PR DESCRIPTION
The minimum balance requirement (MBR) was discussed in six places. The per-resource contributions were restated in more than one file, and the condition for a transaction failing to meet the requirement appeared in several, each scoped to a particular transaction type or resource.

This consolidates the discussion so that MBR increments are noted where the resource they pay for is described, and failure to meet the requirement is stated in exactly one place, applying to all transactions.

### One definition

`ledger-account-state.md` gains a **Minimum Balance Requirement** section defining $\mathrm{MBR}(\rho, I)$: the base requirement plus a contribution for assets held, applications created, applications opted in to, sponsored extra program pages, summed state schemas, and boxes. Each term links to the section that specifies it.

### One failure rule

In `ledger-validation.md`, the account state validity condition now reads $\mathrm{Stake}(\rho+1, I) \geq \mathrm{MBR}(\rho+1, I)$. It previously counted only assets, so it did not account for applications, schemas, extra program pages, or boxes. A second condition enforces `MaximumMinimumBalance`, which was defined as a parameter but never used anywhere in the specification.

The surrounding prose makes explicit what the conditions already imply: they are the only balance-vs-MBR requirements, they hold for every affected account rather than just the sender, contributions net within a single transaction (including across inner transactions and box operations), and they must hold at every intermediate state, so a group may not leave an account below its requirement and restore it later.

### Increments only, per resource

Assets, applications, and boxes keep their contribution amounts. The restatements of the asset amounts in `ledger-txn-semantics-asset.md` and of the application amounts in the `ledger-applications.md` preamble became cross-references. **App Minimum Balance Changes** is now **App Minimum Balance Contributions**, organized by which account bears each part, which makes the size sponsor's share explicit. The per-transaction `FAILS` statement in **Size Sponsor** is gone; that case is now one of the examples given with the central rule.

### One behavioral correction

`avm-ops-state-access.md` said that a box opcode fails if the application account does not possess the new minimum balance. `roundCowState.NewBox` performs no balance check, and the requirement is enforced in `BlockEvaluator.checkMinBalance` after the top-level transaction completes. The text now says the MBR change is immediate and observable through `min_balance`, while the requirement itself is enforced for the transaction as a whole.

Anchor renames: `#asset-minimum-balance-changes` to `#asset-minimum-balance-contribution`, and `#app-minimum-balance-changes` to `#app-minimum-balance-contributions`. No links within the book break.