### PR TITLE
docs: correct MBR exemptions for empty balance records and special addresses

### DIFF
--- a/src/ledger/ledger-account-state.md
+++ b/src/ledger/ledger-account-state.md
@@ -108,13 +108,18 @@ balance requirements at the time of block proposal).
 An account's participation keys and voting stake from a recent round is returned
 by the \\( \Record \\) procedure in the [Byzantine Agreement Protocol](../abft/abft.md).
 
-There exist two special addresses:
+There exist three special addresses:
 
 - \\( I_\mathrm{pool} \\), the address of the _incentive pool_,
 
-- \\( I_f \\), the address of the _fee sink_.
+- \\( I_f \\), the address of the _fee sink_,
 
-For both of these accounts, \\( p_I = 2 \\).
+- \\( I_\mathrm{sp} \\), the address of the [State Proof sender](./ledger-txn-state-proof.md#validation).
+
+For the incentive pool and the fee sink, \\( p_I = 2 \\).
+
+All three addresses are exempt from the minimum balance conditions of the [account state
+validity conditions](./ledger-validation.md).
 
 ## Minimum Balance Requirement
 

--- a/src/ledger/ledger-account-state.md
+++ b/src/ledger/ledger-account-state.md
@@ -57,7 +57,7 @@ $$
 \Stake(r, I) = a_I + (T_r - a^\ast_I) \left\lfloor \frac{a_I}{A} \right\rfloor
 $$
 
-unless \\( p_I = 2 \\) (see below), in which case:
+unless the account is _non-participating_ (i.e. \\( p_I = 2 \\), defined below), in which case:
 
 $$
 \Stake(r, I) = a_I

--- a/src/ledger/ledger-validation.md
+++ b/src/ledger/ledger-validation.md
@@ -156,33 +156,30 @@ a_{\rho_k, I_\mathrm{pool}} = a_{\rho_{k-1}, I_\mathrm{pool}} - R_r(\Units(r))
 $$
 
 An account state in the intermediate state \\( \rho+1 \\) and at round \\( r \\)
-is valid if all following conditions hold:
+is valid if all following conditions hold, where \\( I_\mathrm{sp} \\) is the special
+[State Proof sender](./ledger-txn-state-proof.md#validation) address:
 
 - For all addresses \\( I \notin \\{I_\mathrm{pool}, I_f, I_\mathrm{sp}\\} \\), either the
-account’s [balance record](./ledger-account-state.md) at \\( \rho+1 \\) is _empty_
-or \\( \Stake(\rho+1, I) \geq \MBR(\rho+1, I) \\), where \\( \MBR(\rho+1, I) \\) is the
+account’s [balance record](./ledger-account-state.md) at \\( \rho+1 \\) is _empty_ - it holds
+no μALGO, every other field is zero, and it is responsible for no resource - or
+\\( \Stake(\rho+1, I) \geq \MBR(\rho+1, I) \\), where \\( \MBR(\rho+1, I) \\) is the
 account’s [minimum balance requirement](./ledger-account-state.md#minimum-balance-requirement).
-A balance record is empty when every one of its fields is zero, so the account holds
-no μALGO and is responsible for no resources.
+An account responsible for any resource - for example an application account that holds a
+[box](./ledger-applications.md#boxes) - is therefore never exempt, and a zero balance leaves
+it in an invalid account state.
 
 - For all addresses \\( I \notin \\{I_\mathrm{pool}, I_f, I_\mathrm{sp}\\} \\), if
 \\( \MaximumMinimumBalance \neq 0 \\), then \\( \MBR(\rho+1, I) \leq \MaximumMinimumBalance \\).
 
 - \\( \sum_I \Stake(\rho+1, I) = \sum_I \Stake(\rho, I) \\).
 
-where \\( I_\mathrm{sp} \\) is the special [State Proof sender](./ledger-txn-state-proof.md#validation)
-address. The incentive pool, the fee sink, and the State Proof sender are the only
-accounts exempt from both minimum balance conditions.
+The incentive pool, the fee sink, and the State Proof sender are the only accounts exempt
+unconditionally from the two minimum balance conditions.
 
 These two minimum balance conditions are the only requirements the Ledger places on an
 account’s balance relative to its minimum balance requirement, and they apply to every
 transaction type. A transaction whose effects would leave any account in an invalid
 account state **FAILS**, and its effects are discarded.
-
-Note that the exemption in the first condition is for an account whose balance record
-holds nothing at all; an account that is responsible for any resource - for example an
-application account that holds a [box](./ledger-applications.md#boxes) - **MUST** satisfy
-its minimum balance requirement even when its balance is zero.
 
 Because the conditions hold over all addresses, they constrain every account a transaction
 affects, not only its sender: for example, the receiver of a payment, an application

--- a/src/ledger/ledger-validation.md
+++ b/src/ledger/ledger-validation.md
@@ -158,19 +158,31 @@ $$
 An account state in the intermediate state \\( \rho+1 \\) and at round \\( r \\)
 is valid if all following conditions hold:
 
-- For all addresses \\( I \notin \\{I_\mathrm{pool}, I_f\\} \\), either \\( \Stake(\rho+1, I) = 0 \\)
+- For all addresses \\( I \notin \\{I_\mathrm{pool}, I_f, I_\mathrm{sp}\\} \\), either the
+account’s [balance record](./ledger-account-state.md) at \\( \rho+1 \\) is _empty_
 or \\( \Stake(\rho+1, I) \geq \MBR(\rho+1, I) \\), where \\( \MBR(\rho+1, I) \\) is the
 account’s [minimum balance requirement](./ledger-account-state.md#minimum-balance-requirement).
+A balance record is empty when every one of its fields is zero, so the account holds
+no μALGO and is responsible for no resources.
 
-- For all addresses \\( I \notin \\{I_\mathrm{pool}, I_f\\} \\), if
+- For all addresses \\( I \notin \\{I_\mathrm{pool}, I_f, I_\mathrm{sp}\\} \\), if
 \\( \MaximumMinimumBalance \neq 0 \\), then \\( \MBR(\rho+1, I) \leq \MaximumMinimumBalance \\).
 
 - \\( \sum_I \Stake(\rho+1, I) = \sum_I \Stake(\rho, I) \\).
+
+where \\( I_\mathrm{sp} \\) is the special [State Proof sender](./ledger-txn-state-proof.md#validation)
+address. The incentive pool, the fee sink, and the State Proof sender are the only
+accounts exempt from both minimum balance conditions.
 
 These two minimum balance conditions are the only requirements the Ledger places on an
 account’s balance relative to its minimum balance requirement, and they apply to every
 transaction type. A transaction whose effects would leave any account in an invalid
 account state **FAILS**, and its effects are discarded.
+
+Note that the exemption in the first condition is for an account whose balance record
+holds nothing at all; an account that is responsible for any resource - for example an
+application account that holds a [box](./ledger-applications.md#boxes) - **MUST** satisfy
+its minimum balance requirement even when its balance is zero.
 
 Because the conditions hold over all addresses, they constrain every account a transaction
 affects, not only its sender: for example, the receiver of a payment, an application


### PR DESCRIPTION
## Summary

Corrects the minimum balance requirement (MBR) exemptions in the account state validity conditions to match the reference implementation, and tidies the surrounding prose.

- The first condition previously exempted accounts with zero stake. The reference implementation instead skips accounts whose whole balance record is empty, so an account with a zero balance that is still responsible for a resource is *not* exempt. The condition now says that.
- The State Proof sender address is exempt from both minimum balance conditions in the reference implementation, but was not listed in either. It is now exempt in both, defined before first use, and listed alongside the incentive pool and the fee sink in the Account State section (with `p_I = 2` kept scoped to the pool and fee sink, which is where it applies).
- "Empty" is defined without relying on resource counts that the balance record field list does not include, the exemption for the three special addresses is described as unconditional so it does not read as contradicting the empty record case, and a trailing note that required an unsatisfiable MBR was folded into the condition it clarifies.
- The forward reference to `p_I = 2` in the voting stake definition now names the condition it stands for (_non-participating_), rather than pointing ahead to the definition with no hint of its meaning.
