### PR TITLE
docs: ABFT corrections

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -6,6 +6,7 @@ exclude = ["src/SUMMARY.md"]
 # Remove when jsonspec.md link is fixed
 "src/_include/auto/opcodes/byte-array-manipulation.md" = ["MD057"]
 "src/avm/avm-appendix-a.md" = ["MD057"]
+"src/abft/abft-messages.md" = ["MD075"]
 
 [MD013]
 code-blocks = false

--- a/src/abft/abft-broadcast-rules.md
+++ b/src/abft/abft-broadcast-rules.md
@@ -185,13 +185,13 @@ At most one soft vote is broadcast.
 In other words, in the carried-value case,
 
 $$
-N(S, L, t(\FilterTimeout(p), p)) = (S', L, \Vote(I, r, p, \Soft, c));
+N(S, L, t(\FilterTimeout(p), p)) = (S', L, (\Vote(I, r, p, \Soft, c)));
 $$
 
 while in either frozen-value case,
 
 $$
-N(S, L, t(\FilterTimeout(p), p)) = (S', L, \Vote(I, r, p, \Soft, \mu));
+N(S, L, t(\FilterTimeout(p), p)) = (S', L, (\Vote(I, r, p, \Soft, \mu)));
 $$
 
 and otherwise,

--- a/src/abft/abft-broadcast-rules.md
+++ b/src/abft/abft-broadcast-rules.md
@@ -1,16 +1,8 @@
 {{#include ../_include/tex-macros/domain-separators.md}}
 
 $$
-\newcommand \pk {\mathrm{pk}}
 \newcommand \sk {\mathrm{sk}}
 \newcommand \Vote {\mathrm{Vote}}
-\newcommand \fv {\text{first}}
-\newcommand \Record {\mathrm{Record}}
-\newcommand \lv {\text{last}}
-\newcommand \Stake {\mathrm{Stake}}
-\newcommand \Seed {\mathrm{Seed}}
-\newcommand \CommitteeThreshold {\mathrm{CommitteeThreshold}}
-\newcommand \CommitteeSize {\mathrm{CommitteeSize}}
 \newcommand \Sign {\mathrm{Sign}}
 \newcommand \Bundle {\mathrm{Bundle}}
 \newcommand \Soft {\mathit{soft}}
@@ -33,25 +25,15 @@ Upon observing messages or receiving timeout events, the player state
 machine emits network outputs, which are externally visible. The
 player may also append an entry to the ledger.
 
-A correct player emits only valid votes. Suppose the player is
-identified with the address \\( I \\) and possesses the secret key \\( \sk \\),
-and the agreement is occurring on the ledger \\(L\\). Then the player
-constructs a vote \\( \Vote(I, r, p, s, v) \\) by doing the following:
-
-- Let
-  - \\(( \pk, B, r_\fv, r_\lv) = \Record(L, r - \delta_b, I) \\),
-  - \\( \bar{B} = \Stake(L, r - \delta_b, r) \\),
-  - \\( Q = \Seed(L, r - \delta_s) \\),
-  - \\( \tau = \CommitteeThreshold(s) \\),
-  - \\( \bar{\tau} = \CommitteeSize(s) \\).
-
-- Let \\( x = \Domain{VO} || \Encoding((I, r, p, s, v)) \\), and \\( x' = \Domain{AS} || \Encoding((Q, r, p, s)) \\).
-
-- Try to set \\( y := \Sign(x, x', \sk, B, \bar{B}, Q, \tau, \bar{\tau}) \\).
-
-If the signing procedure succeeds, the player broadcasts
-\\( \Vote(I, r, p, s, v) = (I, r, p, s, v, y) \\). Otherwise, the player
-does not broadcast anything.
+A correct player emits only valid votes. Suppose the player is identified
+with the address \\( I \\) and possesses the secret key \\( \sk \\), and the
+agreement is occurring on the ledger \\( L \\). The player constructs
+\\( \Vote(I, r, p, s, v) \\) by attempting
+\\( y := \Sign(x, x', \sk, B, \bar{B}, Q, \tau, \bar{\tau}) \\) with the
+parameters of the [vote validity conditions](./abft-messages.md#votes). If
+signing succeeds, the player broadcasts
+\\( \Vote(I, r, p, s, v) = (I, r, p, s, v, y) \\); otherwise, the player does
+not broadcast anything.
 
 For certain broadcast vote-messages specified here, a node is
 forbidden to _equivocate_ (i.e., produce a pair of votes which contain

--- a/src/abft/abft-broadcast-rules.md
+++ b/src/abft/abft-broadcast-rules.md
@@ -1,3 +1,5 @@
+{{#include ../_include/tex-macros/domain-separators.md}}
+
 $$
 \newcommand \pk {\mathrm{pk}}
 \newcommand \sk {\mathrm{sk}}
@@ -15,13 +17,11 @@ $$
 \newcommand \Cert {\mathit{cert}}
 \newcommand \Proposal {\mathrm{Proposal}}
 \newcommand \Entry {\mathrm{Entry}}
-\newcommand \Rand {\mathrm{Rand}}
 \newcommand \Hash {\mathrm{Hash}}
 \newcommand \Digest {\mathrm{Digest}}
 \newcommand \Encoding {\mathrm{Encoding}}
 \newcommand \FilterTimeout {\mathrm{FilterTimeout}}
 \newcommand \Next {\mathit{next}}
-\newcommand \DeadlineTimeout {\mathrm{DeadlineTimeout}}
 \newcommand \Late {\mathit{late}}
 \newcommand \Redo {\mathit{redo}}
 \newcommand \Down {\mathit{down}}
@@ -40,17 +40,17 @@ constructs a vote \\( \Vote(I, r, p, s, v) \\) by doing the following:
 
 - Let
   - \\(( \pk, B, r_\fv, r_\lv) = \Record(L, r - \delta_b, I) \\),
-  - \\( \bar{B} = \Stake(L, r - \delta_b) \\),
+  - \\( \bar{B} = \Stake(L, r - \delta_b, r) \\),
   - \\( Q = \Seed(L, r - \delta_s) \\),
   - \\( \tau = \CommitteeThreshold(s) \\),
   - \\( \bar{\tau} = \CommitteeSize(s) \\).
 
-- Encode \\( x := (I, r, p, s, v), x' := (I, r, p, s) \\).
+- Let \\( x = \Domain{VO} || \Encoding((I, r, p, s, v)) \\), and \\( x' = \Domain{AS} || \Encoding((Q, r, p, s)) \\).
 
 - Try to set \\( y := \Sign(x, x', \sk, B, \bar{B}, Q, \tau, \bar{\tau}) \\).
 
 If the signing procedure succeeds, the player broadcasts
-\\( Vote(I, r, p, s, v) = (I, r, p, s, v, y) \\). Otherwise, the player
+\\( \Vote(I, r, p, s, v) = (I, r, p, s, v, y) \\). Otherwise, the player
 does not broadcast anything.
 
 For certain broadcast vote-messages specified here, a node is
@@ -72,79 +72,81 @@ Where specified, a player attempts to resynchronize.
 
 A resynchronization attempt involves the following stages.
 
+A resynchronization attempt has no output unless \\( s \geq \Next_3 \\) or \\( p \geq 3 \\).
+
 First, the player broadcasts its _freshest bundle_, if one exists.
 
-A player's freshest bundle is a complete bundle defined as follows:
-
-- \\( \Bundle(r, p, \Soft, v) \subset V \\) for some \\( v \\), if it exists, or
-else
-
-- \\( \Bundle(r, p-1, s, \bot) \subset V \\) for some \\( s > \Cert \\), if it exists,
-or else
-
-- \\( \Bundle(r, p-1, s, v) \subset V \\) for some \\( s > \Cert, v \neq \bot \\),
-if it exists.
+A player's freshest bundle is a bundle \\( \Bundle(r, q, s_q, v) \\) proving the
+maximal threshold, under the ordering in [Player State](./abft-player-state.md),
+among the thresholds observed for round \\( r \\).
 
 > [!IMPORTANT]
 > **IMPLEMENTATION:**
 >
 > Freshness relation [reference implementation](https://github.com/algorand/go-algorand/blob/b6e5bcadf0ad3861d4805c51cbf3f695c38a93b7/agreement/events.go#L745).
 
-Second, if the player broadcasted a bundle \\( \Bundle(r, p, s, v) \\), and \\( v \neq \bot \\),
-then the player broadcasts \\( \Proposal(v) \\) if the player has it.
+Second, let \\( q \\) be the period of the freshest bundle if \\( v \neq \bot \\),
+or \\( q = 0 \\) if \\( p = 0 \\), and otherwise undefined. If \\( q \\) is
+defined, the player broadcasts the payload \\( \Proposal(w) \\), where
+\\( w = \sigma(S, r, q) \\) if it is committable, or else \\( w = \bar{v} \\) if
+\\( \Proposal(\bar{v}) \in P \\); if neither exists, no payload is broadcast.
+The relative order of these outputs is unspecified.
 
 Specifically, a resynchronization attempt:
 
-- Corresponds to no additional outputs if no freshest bundle exists
+- Corresponds to no additional outputs if the attempt is inactive, or neither bundle nor payload is available
 
 $$
 N(S, L, \ldots) = (S', L', \ldots),
 $$
 
-- Corresponds to a broadcast of the freshest bundle after a relay output and before
-any subsequent broadcast outputs, if said bundle exists, no matching proposal exists
+- Corresponds to a broadcast of the freshest bundle, if said bundle exists and no proposal
+payload is broadcast
 
 $$
-N(S, L, \ldots) = (S', L', (\ldots, \Bundle^\ast(r, p, s, v), \ldots)),
+N(S, L, \ldots) = (S', L', (\ldots, \Bundle(r, q, s_q, v), \ldots)),
 $$
 
-- Otherwise corresponds to a broadcast of both a bundle and its associated
-proposal after a relay output and before any subsequent broadcast
-outputs
+- Corresponds to a broadcast of both the bundle and the selected proposal payload
+\\( \Proposal(w) \\), if said bundle exists and a payload is broadcast
 
 $$
-N(S, L, \ldots) = (S', L', (\ldots, \Bundle^\ast(r, p, s, v), \Proposal(v), \ldots)).
+N(S, L, \ldots) = (S', L', (\ldots, \Bundle(r, q, s_q, v), \Proposal(w), \ldots)).
+$$
+
+- In \\( p = 0 \\), may correspond to a payload broadcast without a bundle
+
+$$
+N(S, L, \ldots) = (S', L', (\ldots, \Proposal(w), \ldots)).
 $$
 
 ## Proposals
 
-On observing that \\( (r, p) \\) has begun, the player attempts to
-resynchronize, and then
+Before entering a period \\( p \neq 0 \\), the player attempts to resynchronize
+using its old state.
 
-- if \\( p = 0 \\) or there exists some \\( s > \Cert \\) where \\( \Bundle(r, p-1, s, \bot) \\)
-was observed, then a player generates a new proposal \\( (v', \Proposal(v')) \\) and
+On observing that \\( (r, p) \\) has begun,
+
+- if \\( p = 0 \\), or the period began due to a next threshold for \\( \bot \\), the
+player generates a new proposal \\( (v', \Proposal(v')) \\) and
 then broadcasts \\( (\Vote(I, r, p, 0, v'), \Proposal(v')) \\).
 
-- if \\( p > 0 \\) and there exists some \\( s_0 > \Cert, v \\) where \\( \Bundle(r, p-1, s_0, v) \\)
-was observed, while there exists no \\( s_1 > \Cert \\) where \\( \Bundle(r, p-1, s_1, \bot) \\)
-was observed, then the player broadcasts \\( \Vote(I, r, p, 0, v) \\). Moreover, if
-\\( \Proposal(v) \in P \\), the player then broadcasts \\( \Proposal(v) \\).
+- if \\( p > 0 \\) and the period began due to a next threshold for
+\\( v \neq \bot \\), the player broadcasts \\( \Vote(I, r, p, 0, v) \\); if
+\\( \Proposal(v) \in P \\), the payload follows per [Reproposal Payloads](#reproposal-payloads).
+
+A \\( \Soft \\) or \\( \Cert \\) threshold that fast-forwards the player to its period causes neither action.
 
 A player generates a new proposal by executing the entry-generation
-procedure and by setting the fields of the proposal
-accordingly. Specifically, the player creates a proposal payload
-\\( ((o, s), y) \\) by setting
+and [Seed](./abft-messages.md#seed) procedures; \\( Q \\) and \\( \gamma \\) are the
+seed and proof defined by the latter. Specifically, the player creates a proposal payload
+\\( \pi = (e, \gamma, p, I) \\) by setting
 
-- \\( o := \Entry(L) \\),
+- \\( o := \Entry(L, Q) \\),
 
-- \\( Q := \Seed(L, r-1) \\),
+- \\( e := (o, Q) \\).
 
-- \\( y := \Sign(Q, Q, 0, 0, 0, 0, 0, 0) \\),
-
-- and \\( s := \Rand(y, \pk)\\) if \\( p = 0 \\) or \\( s := \Hash(\Seed(L, r-1)) \\)
-otherwise.
-
-This consequently defines the matching proposal-value \\( v = (I, p, \Digest(e), \Hash(\Encoding(e))) \\).
+The matching proposal-value is \\( v' := (I, p, \Digest(e), \Hash(\Domain{PL} || \Encoding(\pi))) \\).
 
 > [!NOTE]
 > For an in-depth overview of how proposal generation may be implemented, refer
@@ -159,71 +161,68 @@ $$
 while if the player broadcasts an old proposal,
 
 $$
-N(S, L, \ldots) = (S', L', (\ldots, \Vote(I, r, p-1, 0, v), \Proposal(v)))
+N(S, L, \ldots) = (S', L', (\ldots, \Vote(I, r, p, 0, v))).
 $$
-
-if \\( \Proposal(v) \in P \\) and
-
-$$
-N(S, L, \ldots) = (S', L', (\ldots, \Vote(I, r, p-1, 0, v)))
-$$
-
-otherwise.
 
 ## Reproposal Payloads
 
-On observing \\( \Vote(I, r, p, 0, v) \\), if \\( \Proposal(v) \in P \\) then the
-player broadcasts \\( \Proposal(v) \\).
+On accepting a \\( \Vote(I, r, p, 0, v) \\), if \\( \Proposal(v) \in P \\), the
+player broadcasts the proposal vote and proposal payload, in place of the vote
+relay.
 
 In other words, if \\( \Proposal(v) \in P \\),
 
 $$
-N(S, L, \Vote(I, r, p, 0, v)) = (S', L', (\Proposal(v))).
+N(S, L, \Vote(I, r, p, 0, v)) = (S', L', (\Vote(I, r, p, 0, v), \Proposal(v))).
 $$
 
 ## Filtering
 
-On observing a timeout event of \\( \FilterTimeout(p) \\) (where
-\\( \mu = (H, H', l, p_\mu) = \mu(S, r, p) \\)),
+On observing a timeout event of \\( \FilterTimeout(p) \\), let
+\\( \mu = (I_\mu, p_\mu, d_\mu, h_\mu) = \mu(S, r, p) \\), and let
+\\( (b, c) = C(S, r, p-1) \\) (see [Player State](./abft-player-state.md))
+when \\( p > 0 \\), or \\( (b, c) = (0, \bot) \\) otherwise.
+The first applicable rule is used:
 
-- if \\( \mu \neq \bot \\) and if
-  - \\( p_\mu = p \\) or
-  - there exists some \\( s > \Cert \\) such that \\( \Bundle(r, p-1, s, \mu) \\)
-was observed then the player broadcasts \\( \Vote(I, r, p, \Soft, \mu) \\).
+- if \\( p > 0 \\), \\( b = 0 \\), and \\( c \neq \bot \\), the player broadcasts*
+  \\( \Vote(I, r, p, \Soft, c) \\);
 
-- if there exists some \\( s_0 > \Cert \\) such that \\( \Bundle(r, p-1, s_0, \bar{v}) \\)
-was observed and there exists no \\( s_1 > \Cert \\) such that \\( \Bundle(r, p-1, s_1, \bot) \\)
-was observed, then the player broadcasts* \\( \Vote(I, r, p, \Soft, \bar{v}) \\).
+- if \\( \mu = \bot \\), the player does nothing;
 
-- otherwise, the player does nothing.
+- if \\( p_\mu < p \\), the player broadcasts* \\( \Vote(I, r, p, \Soft, \mu) \\)
+  exactly when \\( c = \mu \\); and
+
+- otherwise, the player broadcasts* \\( \Vote(I, r, p, \Soft, \mu) \\).
+
+At most one soft vote is broadcast.
 
 > [!NOTE]
 > For a detailed overview of how the filtering step may be implemented, refer to
 > the Algorand ABFT [non-normative section](./non-normative/abft-nn.md).
 
-In other words, in the first case above,
+In other words, in the carried-value case,
 
 $$
-N(S, L, t(\FilterTimeout(p), p)) = (S, L, \Vote(I, r, p, \Soft, \mu));
+N(S, L, t(\FilterTimeout(p), p)) = (S', L, \Vote(I, r, p, \Soft, c));
 $$
 
-while in the second case above,
+while in either frozen-value case,
 
 $$
-N(S, L, t(\FilterTimeout(p), p)) = (S, L, \Vote(I, r, p, \Soft, \bar{v}));
+N(S, L, t(\FilterTimeout(p), p)) = (S', L, \Vote(I, r, p, \Soft, \mu));
 $$
 
-and if neither case is true,
+and otherwise,
 
 $$
-N(S, L, t(\FilterTimeout(p), p)) = (S, L, \epsilon).
+N(S, L, t(\FilterTimeout(p), p)) = (S', L, \epsilon).
 $$
 
 ## Certifying
 
-On observing that some proposal-value \\( v \\) is committable for its
-current round \\( r \\), and some period \\( p' \geq p \\) (its current period),
-if \\( s \leq \Cert \\), then the player broadcasts*
+On observing that \\( v = \sigma(S, r, p) \\) becomes committable for the
+player's current round and period, if no cert threshold for \\( v \\) was observed
+and \\( s \leq \Cert \\), then the player broadcasts*
 \\( \Vote(I, r, p, \Cert, v) \\). (It can be shown that this occurs either
 after a proposal is received or a soft-vote, which can be part of a
 bundle, is received.)
@@ -253,15 +252,14 @@ $$
 N(S, L, \Proposal(v)) = (S', L, (\ldots, \Vote(I, r, p, \Cert, v)));
 $$
 
-as long as \\( s \leq \Cert \\).
+as long as \\( s \leq \Cert \\) and commitment does not occur.
 
 ## Commitment
 
-On observing \\( \Bundle(r, p, \Cert, v) \\) for some value \\( v \\), the player
-_commits_ the entry \\( e \\) corresponding to \\( \Proposal(v) \\); i.e., the
-player appends \\( e \\) to the sequence of entries on its ledger \\( L \\).
-(Evidently, this occurs either after a vote is received or after a
-bundle is received.)
+On observing \\( \Bundle(r, p, \Cert, v) \\) or its matching validated payload
+\\( \Proposal(v) \\), if it has observed both, the player _commits_ the entry
+\\( e \\) corresponding to \\( \Proposal(v) \\); i.e., the player appends \\( e \\)
+to the sequence of entries on its ledger \\( L \\).
 
 > [!NOTE]
 > For further details on how entry commitment may be implemented, refer to the
@@ -271,40 +269,36 @@ In other words, if observing a cert-vote causes the player to commit
 \\( e \\),
 
 $$
-N(S, L, \Vote(I, r, p, \Cert, v)) = (S', L || e, \ldots));
+N(S, L, \Vote(I, r, p, \Cert, v)) = (S', L || e, \ldots);
 $$
 
 while if observing a bundle causes the player to commit \\( e \\),
 
 $$
-N(S, L, \Bundle(r, p, \Cert, v)) = (S', L || e, \ldots)).
+N(S, L, \Bundle(r, p, \Cert, v)) = (S', L || e, \ldots);
+$$
+
+while if observing a proposal causes the player to commit \\( e \\),
+
+$$
+N(S, L, \Proposal(v)) = (S', L || e, \ldots).
 $$
 
 > [!NOTE]
-> Occasionally, an implementation may not have \\( e \\) at the point \\( e \\)
-> becomes committed. In this case, the implementation may wait until it receives
-> \\( e \\) somehow (perhaps by requesting peers for \\( e \\)). Alternatively,
-> the implementation may continue running the protocol until it receives \\( e \\).
-> However, if the protocol chooses to continue running, it may not transmit any
-> vote for which \\( v \neq \bot \\) until it has committed \\( e \\).
+> A player may observe \\( \Bundle(r, p, \Cert, v) \\) before holding the
+> matching \\( \Proposal(v) \\); it may request \\( e \\) from its peers or
+> continue running the protocol until \\( e \\) arrives.
 
 ## Recovery
 
-On observing a timeout event of
-
-- \\( T = \DeadlineTimeout(p) \\) or
-
-- \\( T = \DeadlineTimeout(p) + 2^{s_t}\lambda + u \\) where
-\\( u \in [0, 2^{s_t}\lambda] \\) sampled uniformly at random,
-
-the player attempts to resynchronize and then broadcasts*
+On observing a timeout event \\( t(T, p) \\) that sets \\( s := \Next_h \\)
+(see [New Step](./abft-state-transitions.md#new-step)), the player attempts to
+resynchronize and then broadcasts*
 \\( \Vote(I, r, p, \Next_h, v) \\) where
 
-- \\( v = \sigma(S, r, p) \\) if \\( v \\) is committable in \\( (r, p) \\),
+- \\( v = \sigma(S, r, p) \\) if it is committable in \\( (r, p) \\),
 
-- \\( v = \bar{v} \\) if there does not exist a \\( s_0 > \Cert \\) such that
-\\( \Bundle(r, p-1, s_0, \bot) \\) was observed and there exists an \\( s_1 > \Cert \\)
-such that \\( \Bundle(r, p-1, s_1, \bar{v} )\\) was observed,
+- \\( v = c \\) if \\( p > 0 \\), \\( C(S, r, p-1) = (0, c) \\), and \\( c \neq \bot \\),
 
 - and \\( v = \bot \\) otherwise.
 
@@ -332,10 +326,10 @@ $$
 N(S, L, t(T, p)) = (S', L, (\ldots, \Vote(I, r, p, \Next_h, v)));
 $$
 
-while in the second case,
+while in the carried-value case,
 
 $$
-N(S, L, t(T, p)) = (S', L, (\ldots, \Vote(I, r, p, \Next_h, \bar{v})));
+N(S, L, t(T, p)) = (S', L, (\ldots, \Vote(I, r, p, \Next_h, c)));
 $$
 
 and otherwise,
@@ -346,22 +340,21 @@ $$
 
 ## Fast Recovery
 
-On observing a timeout event of \\( T = k\lambda_f + u \\) where \\( k \\) is a positive
-integer and \\( u \in [0, \lambda_f] \\) sampled uniformly at random, the player
-attempts to resynchronize. Then,
+On observing a timeout event of \\( T = k\lambda_f + u \\), where \\( k \\) is a positive
+integer and \\( u \in [0, \lambda_f) \\) is sampled uniformly at random, the player
+attempts to resynchronize. The first such event after entering a round or period
+lies in \\( [\lambda_f, 2\lambda_f) \\). Then,
 
 - The player broadcasts* \\( \Vote(I, r, p, \Late, v) \\) if \\( v = \sigma(S, r, p) \\)
 is committable in \\( (r, p) \\).
 
-- The player broadcasts* \\( \Vote(I, r, p, \Redo, \bar{v}) \\) if there does not exist
-a \\( s_0 > \Cert \\) such that \\( \Bundle(r, p-1, s_0, \bot) \\) was observed and there
-exists an \\( s_1 > \Cert \\) such that \\( \Bundle(r, p-1, s_1, \bar{v}) \\) was observed.
+- The player broadcasts* \\( \Vote(I, r, p, \Redo, c) \\) if \\( p > 0 \\),
+\\( C(S, r, p-1) = (0, c) \\), and \\( c \neq \bot \\).
 
 - Otherwise, the player broadcasts* \\( \Vote(I, r, p, \Down, \bot) \\).
 
-Finally, the player broadcasts all \\( \Vote(I, r, p, \Late, v) \in V\\), all
-\\( \Vote(I, r, p, \Redo, v) \in V\\), and all \\( \Vote(I, r, p, \Down, \bot) \in V \\)
-that it has observed.
+The player also broadcasts all observed \\( \Late \\), \\( \Redo \\), and \\( \Down \\)
+votes for its current round and period. The relative order of these outputs is unspecified.
 
 > [!IMPORTANT]
 > **IMPLEMENTATION:**

--- a/src/abft/abft-broadcast-rules.md
+++ b/src/abft/abft-broadcast-rules.md
@@ -56,12 +56,12 @@ does not broadcast anything.
 For certain broadcast vote-messages specified here, a node is
 forbidden to _equivocate_ (i.e., produce a pair of votes which contain
 the same round, period, and step but which vote for different proposal
-values). These messages are marked with an asterisk (*) below. To
-prevent accidental equivocation after a power failure, nodes **SHOULD**
-checkpoint their state to crash-safe storage before sending these
-messages.
+values). These messages are marked with an asterisk (*) below.
 
 > [!NOTE]
+> Implementations typically checkpoint their state to crash-safe storage
+> before sending these messages, preventing accidental equivocation after a
+> power failure.
 > For further details on these checkpoint strategies, refer to the
 > [non-normative Ledger specification](../ledger/non-normative/ledger-nn.md). For an in-depth
 > review of broadcasting functionalities, refer to the [non-normative Network specification](../network/network-overview.md).
@@ -97,27 +97,27 @@ Specifically, a resynchronization attempt:
 - Corresponds to no additional outputs if the attempt is inactive, or neither bundle nor payload is available
 
 $$
-N(S, L, \ldots) = (S', L', \ldots),
+N(S, L, \ldots) = (S', L, \ldots),
 $$
 
 - Corresponds to a broadcast of the freshest bundle, if said bundle exists and no proposal
 payload is broadcast
 
 $$
-N(S, L, \ldots) = (S', L', (\ldots, \Bundle(r, q, s_q, v), \ldots)),
+N(S, L, \ldots) = (S', L, (\ldots, \Bundle(r, q, s_q, v), \ldots)),
 $$
 
 - Corresponds to a broadcast of both the bundle and the selected proposal payload
 \\( \Proposal(w) \\), if said bundle exists and a payload is broadcast
 
 $$
-N(S, L, \ldots) = (S', L', (\ldots, \Bundle(r, q, s_q, v), \Proposal(w), \ldots)).
+N(S, L, \ldots) = (S', L, (\ldots, \Bundle(r, q, s_q, v), \Proposal(w), \ldots)).
 $$
 
 - In \\( p = 0 \\), may correspond to a payload broadcast without a bundle
 
 $$
-N(S, L, \ldots) = (S', L', (\ldots, \Proposal(w), \ldots)).
+N(S, L, \ldots) = (S', L, (\ldots, \Proposal(w), \ldots)).
 $$
 
 ## Proposals
@@ -155,13 +155,13 @@ The matching proposal-value is \\( v' := (I, p, \Digest(e), \Hash(\Domain{PL} ||
 In other words, if the player generates a new proposal,
 
 $$
-N(S, L, \ldots) = (S', L', (\ldots, \Vote(I, r, p, 0, v'), \Proposal(v'))),
+N(S, L, \ldots) = (S', L, (\ldots, \Vote(I, r, p, 0, v'), \Proposal(v'))),
 $$
 
 while if the player broadcasts an old proposal,
 
 $$
-N(S, L, \ldots) = (S', L', (\ldots, \Vote(I, r, p, 0, v))).
+N(S, L, \ldots) = (S', L, (\ldots, \Vote(I, r, p, 0, v))).
 $$
 
 ## Reproposal Payloads
@@ -173,7 +173,7 @@ relay.
 In other words, if \\( \Proposal(v) \in P \\),
 
 $$
-N(S, L, \Vote(I, r, p, 0, v)) = (S', L', (\Vote(I, r, p, 0, v), \Proposal(v))).
+N(S, L, \Vote(I, r, p, 0, v)) = (S', L, (\Vote(I, r, p, 0, v), \Proposal(v))).
 $$
 
 ## Filtering
@@ -293,7 +293,7 @@ $$
 
 On observing a timeout event \\( t(T, p) \\) that sets \\( s := \Next_h \\)
 (see [New Step](./abft-state-transitions.md#new-step)), the player attempts to
-resynchronize and then broadcasts*
+resynchronize and broadcasts*
 \\( \Vote(I, r, p, \Next_h, v) \\) where
 
 - \\( v = \sigma(S, r, p) \\) if it is committable in \\( (r, p) \\),
@@ -343,7 +343,7 @@ $$
 On observing a timeout event of \\( T = k\lambda_f + u \\), where \\( k \\) is a positive
 integer and \\( u \in [0, \lambda_f) \\) is sampled uniformly at random, the player
 attempts to resynchronize. The first such event after entering a round or period
-lies in \\( [\lambda_f, 2\lambda_f) \\). Then,
+lies in \\( [\lambda_f, 2\lambda_f) \\). Also,
 
 - The player broadcasts* \\( \Vote(I, r, p, \Late, v) \\) if \\( v = \sigma(S, r, p) \\)
 is committable in \\( (r, p) \\).

--- a/src/abft/abft-ledger.md
+++ b/src/abft/abft-ledger.md
@@ -45,6 +45,9 @@ and last valid rounds for this participating account.
 
 - _Digest Lookup_: \\( \DigestLookup(L, r) = \Digest(e_r) \\).
 
+- _Consensus Parameters_: \\( \mathrm{Parameters}(L, r) \\) is the consensus
+parameter set recorded at round \\( r \\).
+
 - _Total Stake Lookup_: We use \\( \Kcal_{r_b,r_v} \\) to represent all players
 with participation keys at \\( r_b \\) that are eligible to vote at \\( r_v \\).
 Let \\( \Kcal_{r_b,r_v} \\) be the set of all \\( k \\) for which \\( (\pk_{k,r_b},

--- a/src/abft/abft-ledger.md
+++ b/src/abft/abft-ledger.md
@@ -22,7 +22,8 @@ For a detailed definition of this object, see the [Algorand Ledger Specification
 
 The following functions are defined on \\( e \\):
 
-- _Encoding_: \\( \Encoding(e) = x \\) where \\( x \\) is a variable-length bitstring.
+- _Encoding_: \\( \Encoding(e) = x \\) where \\( x \\) is the canonical
+variable-length bitstring encoding of \\( e \\).
 
 - _Summarizing_: \\( \Digest(e) = h \\) where \\( h \\) is a 256-bit integer.
 \\( h \\) should be a cryptographic commitment to the contents of \\( e \\).

--- a/src/abft/abft-messages.md
+++ b/src/abft/abft-messages.md
@@ -128,9 +128,6 @@ Let
 
 - \\( v \\) be a _proposal-value_.
 
-Let \\( x = \Domain{VO} || \Encoding((I, r, p, s, v)) \\), and
-let \\( x' = \Domain{AS} || \Encoding((Q, r, p, s)) \\).
-
 Let \\( y \\) be an arbitrary bitstring.
 
 Then we say that the tuple
@@ -146,6 +143,9 @@ $$
 \Vote(I, r, p, s, v)
 $$
 
+Two votes with equal \\( (I, r, p, s, v) \\) are the _same vote_, regardless of
+\\( y \\); membership of a vote in a set is evaluated on this identity.
+
 > [!IMPORTANT]
 > **IMPLEMENTATION:**
 >
@@ -159,6 +159,9 @@ Let
 - \\( B, \bar{B} \\) be 64-bit integers,
 - \\( Q \\) be a 256-bit integer,
 - \\( \tau, \bar{\tau} \\) 32-bit integers.
+
+Let \\( x = \Domain{VO} || \Encoding((I, r, p, s, v)) \\), and
+let \\( x' = \Domain{AS} || \Encoding((Q, r, p, s)) \\).
 
 We say that this vote is _valid with respect to_ \\( L \\) (or simply _valid_ if
 \\( L \\) is unambiguous) if the following conditions are true:
@@ -315,6 +318,11 @@ if the following conditions are true:
 
 If \\( \pi \\) matches \\( v \\), we write \\( \pi = \Proposal(v) \\).
 
+A proposal payload is transmitted, and relayed, as a pair \\( (\pi, a) \\),
+where \\( a \\) is either empty or a proposal-vote whose proposal-value matches
+\\( \pi \\), called the payload's _authenticator_. A player receiving such a
+pair processes \\( a \\), if present, before \\( \pi \\).
+
 ## Seed
 
 Informally, the protocol interleaves \\( \delta_s \\) seeds in an alternating
@@ -353,7 +361,7 @@ Now \\( I \\) computes the seed \\( Q \\) as follows:
 $$
 Q = \left\\{
 \begin{array}{rl}
-  \Hash(\Domain{PS} || \Encoding((\alpha, \DigestLookup(L, r-\delta_s\delta_r)))) & : r \equiv (r \bmod \delta_s) \mod \delta_r\delta_s \\\\
+  \Hash(\Domain{PS} || \Encoding((\alpha, \DigestLookup(L, r-\delta_s\delta_r)))) & : (r \bmod \delta_s\delta_r) < \delta_s \\\\
   \Hash(\Domain{PS} || \Encoding((\alpha, 0))) & : \text{otherwise}
 \end{array}
 \right.
@@ -379,7 +387,7 @@ and continue to step 4.
 
 1. If \\( p \ne 0 \\), let \\( q_1 = \Hash(\Domain{SD} || q_0) \\). Continue.
 
-1. If \\( r \equiv (r \bmod \delta_s) \mod \delta_r\delta_s \\), then check
+1. If \\( (r \bmod \delta_s\delta_r) < \delta_s \\), then check
 \\( Q = \Hash(\Domain{PS} || \Encoding((q_1, \DigestLookup(L, r-\delta_s\delta_r)))) \\). Otherwise,
 check \\( Q = \Hash(\Domain{PS} || \Encoding((q_1, 0))) \\).
 

--- a/src/abft/abft-messages.md
+++ b/src/abft/abft-messages.md
@@ -1,3 +1,5 @@
+{{#include ../_include/tex-macros/domain-separators.md}}
+
 $$
 \newcommand \Propose {\mathit{propose}}
 \newcommand \Soft {\mathit{soft}}
@@ -38,6 +40,12 @@ Players communicate with each other by exchanging _messages_.
 
 A message is an opaque object containing arbitrary data, save for the fields defined
 below.
+
+Let \\( \Hash \\) be the protocol hash function.
+
+Let \\( \Encoding(x) \\) be the canonical protocol encoding of a structured object \\( x \\).
+
+Domain separators are defined in the [cryptographic specification](../crypto/crypto-domain-separators.md).
 
 > [!NOTE]
 > For a detailed overview of message composition, whether consensus or other types,
@@ -95,14 +103,13 @@ $$
 \right.
 $$
 
-A _proposal-value_ is a tuple \\( v = (I, p, \Digest(e), \Hash(\Encoding(e))) \\)
+A _proposal-value_ associated with a _proposal payload_ \\( \pi \\) containing entry
+\\( e \\) is a tuple \\( v = (I, p, \Digest(e), \Hash(\Domain{PL} || \Encoding(\pi))) \\)
 where:
 
 - \\( I \\) is an address (the "original proposer"),
 
-- \\( p \\) is a period (the "original period"),
-
-- \\( \Hash \\) is some cryptographic hash function.
+- \\( p \\) is a period (the "original period").
 
 The special proposal-value where all fields are the zero-string is called the _bottom
 proposal_ \\( \bot \\).
@@ -121,8 +128,8 @@ Let
 
 - \\( v \\) be a _proposal-value_.
 
-Let \\( x \\) be a canonical encoding of the 5-tuple \\( (I, r, p, s, v) \\), and
-let \\( x' \\) be a canonical encoding of the 4-tuple \\( (I, r, p, s) \\).
+Let \\( x = \Domain{VO} || \Encoding((I, r, p, s, v)) \\), and
+let \\( x' = \Domain{AS} || \Encoding((Q, r, p, s)) \\).
 
 Let \\( y \\) be an arbitrary bitstring.
 
@@ -144,7 +151,7 @@ $$
 >
 > Vote [reference implementation](https://github.com/algorand/go-algorand/blob/b6e5bcadf0ad3861d4805c51cbf3f695c38a93b7/agreement/vote.go#L152).
 
-Moreover, let \\( L \\) be a ledger where \\( \abs{L} \geq \delta_b \\).
+Moreover, let \\( L \\) be a ledger.
 
 Let
 
@@ -174,11 +181,7 @@ We say that this vote is _valid with respect to_ \\( L \\) (or simply _valid_ if
   - If \\( s = 0 \\), then \\( p_{orig} \le p \\).
   - Furthermore, if \\( s = 0 \\) and \\( p = p_{orig} \\), then \\( I = I_{orig} \\).
 
-<!-- This condition is not enforced in the verifying side, only in the `makeVote()`
-side. It would be easy to add this as an additional check. -->
-
-- If \\( s \in \\{ \Propose, \Soft, \Cert, \Late, \Redo\\} \\), \\( v \neq \bot \\).
-Conversely, if \\( s = \Down \\), \\( v = \bot \\).
+- If \\( s \in \\{ \Propose, \Soft, \Cert\\} \\), then \\( v \neq \bot \\).
 
 - Let
   - \\( (\pk, B, r_\fv, r_\lv) = \Record(L, r - \delta_b, I) \\),
@@ -194,6 +197,10 @@ Conversely, if \\( s = \Down \\), \\( v = \bot \\).
 Observe that valid votes contain outputs of the \\( \Sign \\) procedure; i.e.,
 \\( y := \Sign(x, x', \sk, B, \bar{B}, Q, \tau, \bar{\tau}) \\).
 
+A correct player emits non-bottom votes in \\( \Propose \\), \\( \Soft \\),
+\\( \Cert \\), \\( \Late \\), and \\( \Redo \\). Conversely, if \\( s = \Down \\),
+\\( v = \bot \\). Either value is permitted in \\( \Next_s \\).
+
 Informally, these conditions check the following:
 
 - The vote is not too far in the future for \\( L \\) to be able to validate.
@@ -204,9 +211,9 @@ earlier period (\\( p_{orig} < p \\)). But they can't claim to "re-propose" a va
 from a future period. And if the proposal-value is new (\\( p_{orig} = p \\)) then
 the "original proposer" must be the voter.
 
-- The \\( \Propose \\), \\( \Soft \\), \\( \Cert \\), \\( \Late \\), and \\( \Redo \\)
-steps must vote for an actual proposal. The \\( \Down \\) step must only vote
-for \\( \bot \\).
+- The \\( \Propose \\), \\( \Soft \\), and \\( \Cert \\) steps must vote for an
+actual proposal. Correct players also \\( \Late \\)-vote and \\( \Redo \\)-vote only
+for an actual proposal, and \\( \Down \\)-vote only for \\( \bot \\).
 
 - The last condition checks that the vote was properly signed by a voter who was
 selected to serve on the committee for this _round_, _period_, and _step_. The
@@ -246,7 +253,7 @@ and step_ \\( s \\) (or a _bundle for \\( v \\) at_ \\( (r, p, s) \\)), denoted
 >
 > Bundle [reference implementation](https://github.com/algorand/go-algorand/blob/b6e5bcadf0ad3861d4805c51cbf3f695c38a93b7/agreement/bundle.go#L46).
 
-Moreover, let \\( L \\) be a ledger where \\( \abs{L} \geq \delta_b \\).
+Moreover, let \\( L \\) be a ledger.
 
 We say that this bundle is _valid with respect to_ \\( L \\) (or simply _valid_ if
 \\( L \\) is unambiguous) if the following conditions are true:
@@ -260,6 +267,10 @@ We say that this bundle is _valid with respect to_ \\( L \\) (or simply _valid_ 
 > See the [Algorand ABFT non-normative section](./non-normative/abft-nn.md) for
 > further details.
 
+- \\( s \neq \Propose \\).
+
+- \\( |V| \leq \CommitteeThreshold(s) \\).
+
 - Every element \\( a_i \in V \\) is valid with respect to \\( L \\).
 
 - For any two elements \\( a_i, a_j \in V \\), \\( I_i \neq I_j \\).
@@ -269,41 +280,40 @@ We say that this bundle is _valid with respect to_ \\( L \\) (or simply _valid_ 
 - For any element \\( a_i \in V \\), either \\( a_i \\) is a vote and \\( v_i = v \\),
 or \\( a_i \\) is an equivocation vote.
 
-- Let \\( w_i \\) be the weight of the signature in \\( a_i \\). Then
+- Let \\( w_i \\) be the weight of \\( a_i \\), where an equivocation vote has the
+common weight of its constituent votes. Then
 \\( \sum_i w_i \geq \CommitteeThreshold(s) \\).
 
 ## Proposals
 
-Let \\( e = (o, s) \\) be an entry and \\( y \\) be the output of a \\( \Sign \\)
-procedure.
+Let \\( e = (o, Q) \\) be an entry, \\( \gamma \\) a seed proof, \\( I_o \\) an
+address, and \\( p_o \\) a period.
 
-The pair \\( (e, y) \\) is a _proposal_ or a _proposal payload_.
+The tuple \\( \pi = (e, \gamma, p_o, I_o) \\) is a _proposal_ or _proposal payload_.
 
 Moreover, let
 
-- \\( L \\) be a ledger where \\( \abs{L} \geq \delta_b \\),
+- \\( L \\) be a ledger,
 
-- \\( v = (I, p, h, x) \\) be some proposal-value.
+- \\( r \\) be the round being decided,
+
+- \\( v \\) be some proposal-value.
 
 We say that this proposal is _a valid proposal matching \\( v \\) with respect to
 \\( L \\)_ (or simply that this proposal _matches \\( v \\)_ if \\( L \\) is unambiguous)
 if the following conditions are true:
 
-- \\( \ValidEntry(L, e) = 1 \\),
+- \\( \ValidEntry(L, o) = 1 \\),
 
-- \\( h = \Digest(e) \\),
+- \\( v = (I_o, p_o, \Digest(e), \Hash(\Domain{PL} || \Encoding(\pi))) \\),
 
-- \\( x = \Hash(\Encoding(e)) \\),
+- The entry's round is \\( r \\),
 
-- The seed \\( s \\) and seed proof are valid as specified in the following section,
+- The seed \\( Q \\) and seed proof \\( \gamma \\) are valid as specified in the following section,
 
-- Let \\( (\pk, B, r_\fv, r_\lv) = \Record(L, r - \delta_b, I) \\),
-  - If \\( p = 0 \\), then \\( \Verify(y, Q_0, Q_0, \pk, 0, 0, 0, 0, 0) \neq 0 \\),
+- If \\( e \\) identifies a proposer, that proposer is \\( I_o \\).
 
-- Let \\( (\pk, B, r_\fv, r_\lv) = \Record(L, r - \delta_b, I) \\).
-Then \\( r_\fv \leq r \leq r_\lv \\).
-
-If \\( e \\) matches \\( v \\), we write \\( e = \Proposal(v) \\).
+If \\( \pi \\) matches \\( v \\), we write \\( \pi = \Proposal(v) \\).
 
 ## Seed
 
@@ -321,30 +331,35 @@ Let
 
 - \\( (\pk, B, r_\fv, r_\lv) = \Record(L, r - \delta_b, I) \\),
 
-- \\( \sk \\) be the secret key corresponding to \\( \pk \\),
+- \\( \sk_{\mathrm{sel}} \\) be the \\( \VRF \\) secret key associated with \\( \pk \\),
+
+- \\( q_0 = \Seed(L, r - \delta_s) \\),
 
 - \\( \alpha \\) be a 256-bit integer.
 
-Then \\( I \\) computes the seed proof \\( y \\) for a new entry as follows:
+Then \\( I \\) computes the seed proof \\( \gamma \\) for a new entry as follows:
 
 - If \\( p = 0 \\):
-  - \\( y = \VRF.\Prove(\Seed(L, r-\delta_s), \sk) \\),
-  - \\( \alpha = \Hash(\VRF.\ProofToHash(y), I) \\).
+  - \\( \gamma = \VRF.\Prove(\Domain{SD} || q_0, \sk_{\mathrm{sel}}) \\),
+  - \\( z = \VRF.\ProofToHash(\gamma) \\),
+  - \\( \alpha = \Hash(\Domain{PS} || \Encoding((I, z))) \\).
 
 - If \\( p \ne 0 \\):
-  - \\( y = 0 \\),
-  - \\( \alpha = \Hash(\Seed(L, r-\delta_s)) \\).
+  - \\( \gamma = 0 \\),
+  - \\( \alpha = \Hash(\Domain{SD} || q_0) \\).
 
 Now \\( I \\) computes the seed \\( Q \\) as follows:
 
 $$
 Q = \left\\{
 \begin{array}{rl}
-  H(\alpha, \DigestLookup(L, r-\delta_s\delta_r)) & : (r \bmod \delta_s\delta_r) < \delta_s \\\\
-  H(\alpha) & : \text{otherwise}
+  \Hash(\Domain{PS} || \Encoding((\alpha, \DigestLookup(L, r-\delta_s\delta_r)))) & : r \equiv (r \bmod \delta_s) \mod \delta_r\delta_s \\\\
+  \Hash(\Domain{PS} || \Encoding((\alpha, 0))) & : \text{otherwise}
 \end{array}
 \right.
 $$
+
+where \\( 0 \\) denotes the zero digest.
 
 > [!IMPORTANT]
 > **IMPLEMENTATION:**
@@ -354,17 +369,19 @@ $$
 The seed is valid if the following verification procedure succeeds:
 
 1. Let \\( (\pk, B, r_\fv, r_\lv) = \Record(L, r-\delta_b, I) \\);
+let \\( \pk_{\mathrm{sel}} \\) be the \\( \VRF \\) public key associated with
+\\( \pk \\), and
 let \\( q_0 = \Seed(L, r-\delta_s) \\).
 
-1. If \\( p = 0 \\), check \\( \VRF.\Verify(y, q_0, \pk) \\), immediately
-returning failure if verification fails. Let \\( q_1 = \Hash(\VRF.\ProofToHash(y), I) \\)
+1. If \\( p = 0 \\), check \\( \VRF.\Verify(\gamma, \Domain{SD} || q_0, \pk_{\mathrm{sel}}) = 1 \\), immediately
+returning failure if verification fails. Let \\( q_1 = \Hash(\Domain{PS} || \Encoding((I, \VRF.\ProofToHash(\gamma)))) \\)
 and continue to step 4.
 
-1. If \\( p \ne 0 \\), let \\( q_1 = \Hash(q_0) \\). Continue.
+1. If \\( p \ne 0 \\), let \\( q_1 = \Hash(\Domain{SD} || q_0) \\). Continue.
 
 1. If \\( r \equiv (r \bmod \delta_s) \mod \delta_r\delta_s \\), then check
-\\( Q = \Hash(q_1||\DigestLookup(L, r-\delta_s\delta_r)) \\). Otherwise,
-check \\( Q = q_1 \\).
+\\( Q = \Hash(\Domain{PS} || \Encoding((q_1, \DigestLookup(L, r-\delta_s\delta_r)))) \\). Otherwise,
+check \\( Q = \Hash(\Domain{PS} || \Encoding((q_1, 0))) \\).
 
 > [!NOTE]
 > Round \\( r \\) leader selection and committee selection both use the seed from

--- a/src/abft/abft-messages.md
+++ b/src/abft/abft-messages.md
@@ -43,8 +43,6 @@ below.
 
 Let \\( \Hash \\) be the protocol hash function.
 
-Let \\( \Encoding(x) \\) be the canonical protocol encoding of a structured object \\( x \\).
-
 Domain separators are defined in the [cryptographic specification](../crypto/crypto-domain-separators.md).
 
 > [!NOTE]
@@ -104,12 +102,15 @@ $$
 $$
 
 A _proposal-value_ associated with a _proposal payload_ \\( \pi \\) containing entry
-\\( e \\) is a tuple \\( v = (I, p, \Digest(e), \Hash(\Domain{PL} || \Encoding(\pi))) \\)
-where:
+\\( e \\) is a tuple \\( v = (I, p, d, h) \\) where:
 
 - \\( I \\) is an address (the "original proposer"),
 
-- \\( p \\) is a period (the "original period").
+- \\( p \\) is a period (the "original period"),
+
+- \\( d = \Digest(e) \\) is the entry digest,
+
+- \\( h = \Hash(\Domain{PL} || \Encoding(\pi)) \\) is the payload commitment.
 
 The special proposal-value where all fields are the zero-string is called the _bottom
 proposal_ \\( \bot \\).

--- a/src/abft/abft-messages.md
+++ b/src/abft/abft-messages.md
@@ -243,6 +243,10 @@ An equivocation vote pair is _valid with respect to_ \\( L \\) (or simply _valid
 if \\( L \\) is unambiguous) if both of its constituent votes are also valid with
 respect to \\( L \\).
 
+An equivocation vote pair is transmitted as a single record carrying the
+common \\( (I, r, p, s) \\) and credential, with the two proposal-values and
+their two signatures.
+
 ## Bundles
 
 Let \\( V \\) be any set of votes and equivocation votes.
@@ -255,6 +259,11 @@ and step_ \\( s \\) (or a _bundle for \\( v \\) at_ \\( (r, p, s) \\)), denoted
 > **IMPLEMENTATION:**
 >
 > Bundle [reference implementation](https://github.com/algorand/go-algorand/blob/b6e5bcadf0ad3861d4805c51cbf3f695c38a93b7/agreement/bundle.go#L46).
+
+A bundle is transmitted as \\( (r, p, s, v) \\) together with its vote and
+equivocation-vote records; a vote record carries only the sender, credential,
+and signature, the omitted fields being the bundle's, while an equivocation
+record is transmitted as above.
 
 Moreover, let \\( L \\) be a ledger.
 

--- a/src/abft/abft-messages.md
+++ b/src/abft/abft-messages.md
@@ -200,9 +200,9 @@ We say that this vote is _valid with respect to_ \\( L \\) (or simply _valid_ if
 Observe that valid votes contain outputs of the \\( \Sign \\) procedure; i.e.,
 \\( y := \Sign(x, x', \sk, B, \bar{B}, Q, \tau, \bar{\tau}) \\).
 
-A correct player emits non-bottom votes in \\( \Propose \\), \\( \Soft \\),
-\\( \Cert \\), \\( \Late \\), and \\( \Redo \\). Conversely, if \\( s = \Down \\),
-\\( v = \bot \\). Either value is permitted in \\( \Next_s \\).
+A correct player emits only votes with \\( v \neq \bot \\) in \\( \Propose \\),
+\\( \Soft \\), \\( \Cert \\), \\( \Late \\), and \\( \Redo \\). Conversely, if
+\\( s = \Down \\), \\( v = \bot \\). Either value is permitted in \\( \Next_s \\).
 
 Informally, these conditions check the following:
 

--- a/src/abft/abft-messages.md
+++ b/src/abft/abft-messages.md
@@ -167,18 +167,6 @@ let \\( x' = \Domain{AS} || \Encoding((Q, r, p, s)) \\).
 We say that this vote is _valid with respect to_ \\( L \\) (or simply _valid_ if
 \\( L \\) is unambiguous) if the following conditions are true:
 
-> [!IMPORTANT]
-> **IMPLEMENTATION:**
->
-> The reference implementation builds an [asynchronous vote verifier](https://github.com/algorand/go-algorand/blob/b6e5bcadf0ad3861d4805c51cbf3f695c38a93b7/agreement/asyncVoteVerifier.go#L52),
-> which builds a verification pool and under the hood uses two different verifying
-> routines: one for [regular unauthenticated votes](https://github.com/algorand/go-algorand/blob/b6e5bcadf0ad3861d4805c51cbf3f695c38a93b7/agreement/vote.go#L97),
-> and one for [unauthenticated equivocation votes](https://github.com/algorand/go-algorand/blob/b6e5bcadf0ad3861d4805c51cbf3f695c38a93b7/agreement/vote.go#L193).
-
-> [!NOTE]
-> See the [Algorand ABFT non-normative section](./non-normative/abft-nn.md) for further
-> details.
-
 - \\( r \leq |L| + 2 \\)
 
 - Let \\( v = (I_{orig}, p_{orig}, d, h )\\).
@@ -248,6 +236,14 @@ An equivocation vote pair is transmitted as a single record carrying the
 common \\( (I, r, p, s) \\) and credential, with the two proposal-values and
 their two signatures.
 
+> [!IMPORTANT]
+> **IMPLEMENTATION:**
+>
+> The reference implementation builds an [asynchronous vote verifier](https://github.com/algorand/go-algorand/blob/b6e5bcadf0ad3861d4805c51cbf3f695c38a93b7/agreement/asyncVoteVerifier.go#L52),
+> which builds a verification pool and under the hood uses two different verifying
+> routines: one for [regular unauthenticated votes](https://github.com/algorand/go-algorand/blob/b6e5bcadf0ad3861d4805c51cbf3f695c38a93b7/agreement/vote.go#L97),
+> and one for [unauthenticated equivocation votes](https://github.com/algorand/go-algorand/blob/b6e5bcadf0ad3861d4805c51cbf3f695c38a93b7/agreement/vote.go#L193).
+
 ## Bundles
 
 Let \\( V \\) be any set of votes and equivocation votes.
@@ -271,15 +267,6 @@ Moreover, let \\( L \\) be a ledger.
 We say that this bundle is _valid with respect to_ \\( L \\) (or simply _valid_ if
 \\( L \\) is unambiguous) if the following conditions are true:
 
-> [!IMPORTANT]
-> **IMPLEMENTATION:**
->
-> The reference implementation makes use of an asynchronous [Bundle verifying function](https://github.com/algorand/go-algorand/blob/b6e5bcadf0ad3861d4805c51cbf3f695c38a93b7/agreement/bundle.go#L147).
-
-> [!NOTE]
-> See the [Algorand ABFT non-normative section](./non-normative/abft-nn.md) for
-> further details.
-
 - \\( s \neq \Propose \\).
 
 - \\( |V| \leq \CommitteeThreshold(s) \\).
@@ -296,6 +283,11 @@ or \\( a_i \\) is an equivocation vote.
 - Let \\( w_i \\) be the weight of \\( a_i \\), where an equivocation vote has the
 common weight of its constituent votes. Then
 \\( \sum_i w_i \geq \CommitteeThreshold(s) \\).
+
+> [!IMPORTANT]
+> **IMPLEMENTATION:**
+>
+> The reference implementation makes use of an asynchronous [Bundle verifying function](https://github.com/algorand/go-algorand/blob/b6e5bcadf0ad3861d4805c51cbf3f695c38a93b7/agreement/bundle.go#L147).
 
 ## Proposals
 

--- a/src/abft/abft-notation.md
+++ b/src/abft/abft-notation.md
@@ -40,15 +40,16 @@ The Algorand protocol's progress is described using a _context tuple_ \\( (r, p,
 which identifies the current state within the Agreement protocol's state machine.
 
 - \\( r \\) (_round_): Indicates the current round of the protocol. It increases monotonically
-and corresponds to the block being committed. It is driven by _protocol threshold
-events_.
+and corresponds to the block being committed. It advances when agreement for the current round
+concludes.
 
 - \\( p \\) (_period_): Indicates the attempt number for reaching agreement in the
 current round[^1]. It is typically zero. A non-zero value reflects recovery from a failed
 commitment attempt. It is driven by _protocol threshold events_.
 
-- \\( s \\) (_step_): Enumerates the stages of the Agreement protocol within a given
-period. It is driven by _protocol time events_.
+- \\( s \\) (_step_): Identifies the player's current timed stage within a given
+period. It is driven by _protocol timeout events_. A vote carries an independent
+_committee step_.
 
 ---
 

--- a/src/abft/abft-parameters.md
+++ b/src/abft/abft-parameters.md
@@ -7,8 +7,9 @@ $$
 
 The Algorand protocol is parameterized by the constants described in this section.
 
-For agreement round \\( r \\), the player **SHALL** use the consensus parameters
-recorded in the Ledger at round \\( \max(r - 2, 0) \\).
+For agreement round \\( r \\), the player **SHALL** use the consensus
+parameters \\( \mathrm{Parameters}(L, \max(r - 2, 0)) \\) recorded in the
+Ledger \\( L \\).
 
 ## Time Constants
 
@@ -36,7 +37,7 @@ For convenience, we define:
 
 - \\( \delta_b = 2\delta_s\delta_r \\) (the "balance lookback").
 
-Every round lookback \\( r - \delta \\) refers to round \\( \max(r - \delta, 0) \\).
+Every round or period lookback \\( a - b \\) refers to \\( \max(a - b, 0) \\).
 
 ## Timeouts
 

--- a/src/abft/abft-parameters.md
+++ b/src/abft/abft-parameters.md
@@ -5,20 +5,23 @@ $$
 
 # Parameters
 
-The Algorand protocol is parameterized by the following constants:
+The Algorand protocol is parameterized by the constants described in this section.
+
+For agreement round \\( r \\), the player **SHALL** use the consensus parameters
+recorded in the Ledger at round \\( \max(r - 2, 0) \\).
 
 ## Time Constants
 
 These values represent durations of _time_.
 
-|         SYMBOL         |    VALUE (s)    | DESCRIPTION                                                                                        |
-|:----------------------:|:---------------:|:---------------------------------------------------------------------------------------------------|
-|    \\( \lambda \\)     |  \\( 2.00 \\)   | Time for small message (e.g., a vote) propagation in ideal network conditions                      |
-| \\( \lambda_{0min} \\) |  \\( 0.25 \\)   | Minimum amount of time for small message propagation in good network conditions, for \\( p = 0 \\) |
-| \\( \lambda_{0max} \\) |  \\( 1.50 \\)   | Maximum amount of time for small message propagation in good network conditions, for \\( p = 0 \\) |
-|   \\( \lambda_f \\)    | \\( 300.00 \\)  | Frequency at which the protocol _fast recovery_ steps are repeated                                 |
-|    \\( \Lambda \\)     |  \\( 17.00 \\)  | Time for big message (e.g., a block) propagation in ideal network conditions                       |
-|   \\( \Lambda_0 \\)    |  \\( 4.00 \\)   | Time for big message propagation in good network conditions, for \\(p = 0\\)                       |
+|         SYMBOL         |   VALUE (s)    | DESCRIPTION                                                                   |
+|:----------------------:|:--------------:|:------------------------------------------------------------------------------|
+|    \\( \lambda \\)     |  \\( 2.00 \\)  | Time for small message (e.g., a vote) propagation in ideal network conditions |
+| \\( \lambda_{0min} \\) |  \\( 2.50 \\)  | Minimum filtering time, for \\( p = 0 \\)                                     |
+| \\( \lambda_{0max} \\) |  \\( 3.00 \\)  | Maximum filtering time, for \\( p = 0 \\)                                     |
+|   \\( \lambda_f \\)    | \\( 300.00 \\) | Frequency at which the protocol _fast recovery_ steps are repeated            |
+|    \\( \Lambda \\)     | \\( 15.00 \\)  | Time for big message (e.g., a block) propagation in ideal network conditions  |
+|   \\( \Lambda_0 \\)    |  \\( 4.00 \\)  | Propagation deadline, for \\( p = 0 \\)                                       |
 
 ## Round Constants
 
@@ -33,22 +36,26 @@ For convenience, we define:
 
 - \\( \delta_b = 2\delta_s\delta_r \\) (the "balance lookback").
 
+Every round lookback \\( r - \delta \\) refers to round \\( \max(r - \delta, 0) \\).
+
 ## Timeouts
 
 We define \\( \FilterTimeout(p) \\) on a _period_ \\( p \\) as follows:
 
-- If \\( p = 0 \\) the \\( \FilterTimeout(p) \\) is calculated dynamically based on the
-lower 95th percentile of the observed lowest credentials per round arrival time:
+- If \\( p = 0 \\):
 
-  - \\( 2\lambda_{0min} \leq \FilterTimeout(p) \leq 2\lambda_{0max} \\)
-
-> [!NOTE]
-> Refer to the [non-normative](./non-normative/abft-nn-dynamic-filter-timeout.md) section
-> for details about the implementation of the dynamic filtering mechanism.
+  - \\( \lambda_{0min} \leq \FilterTimeout(p) \leq \lambda_{0max} \\).
 
 - If \\( p \ne 0 \\):
 
   - \\( \FilterTimeout(p) = 2\lambda \\).
+
+> [!NOTE]
+> In the reference implementation \\( \FilterTimeout(0) \\) is calculated dynamically
+> based on the lower 95th percentile of the observed lowest credentials per round arrival
+> time. Players may choose different values of \\( \FilterTimeout(0) \\) within its
+> range. Agreement safety does not require equal values. An adaptive strategy is
+> described in the [non-normative section](./non-normative/abft-nn-dynamic-filter-timeout.md).
 
 We define \\( \DeadlineTimeout(p) \\) on _period_ \\( p \\) as follows:
 
@@ -58,7 +65,7 @@ We define \\( \DeadlineTimeout(p) \\) on _period_ \\( p \\) as follows:
 
 - If \\( p \ne 0 \\):
 
-  - \\( \DeadlineTimeout(p) = \Lambda \\)
+  - \\( \DeadlineTimeout(p) = \Lambda + \lambda \\)
 
 > [!IMPORTANT]
 > **IMPLEMENTATION:**

--- a/src/abft/abft-participants.md
+++ b/src/abft/abft-participants.md
@@ -33,13 +33,12 @@ Let \\( (\pk_k, \sk_k) \\) be some valid keypair.
 A secret key supports a _signing_ procedure
 
 $$
-y := \Sign(m, m', sk_k, B_k, \bar{B}, Q, \tau, \bar{\tau})
+y := \Sign(m, m', \sk_k, B_k, \bar{B}, Q, \tau, \bar{\tau})
 $$
 
 Where \\( y \\) is opaque and cryptographically resistant to tampering, where defined.
 
-Signing is not defined on many inputs: for any given input, signing may fail to
-produce an output.
+Not every input to \\( \Sign\ \\) produces an output \\( y \\).
 
 The following functions are defined on \\( y \\):
 

--- a/src/abft/abft-player-state.md
+++ b/src/abft/abft-player-state.md
@@ -39,7 +39,7 @@ formation, and freshness comparisons are evaluated in \\( H \\) order.
 We say that a player has _observed_
 
 - \\( \Proposal(v) \\) if \\( \Proposal(v) \in P \\),
-- \\( \Vote(r, p, s, v) \\) if \\( \Vote(r, p, s, v) \in V \\),
+- \\( \Vote(I, r, p, s, v) \\) if \\( \Vote(I, r, p, s, v) \in V \\),
 - \\( \Bundle(r, p, s, v) \\) if \\( \Bundle(r, p, s, v) \subset V \\) and its threshold
 is fresher than every threshold previously observed for round \\( r \\),
 - That the round \\( r > 0 \\) (period \\( p = 0 \\)) has _begun_ if an entry was

--- a/src/abft/abft-player-state.md
+++ b/src/abft/abft-player-state.md
@@ -133,11 +133,9 @@ For thresholds in one round, \\( T_1 \\) is _fresher_ than \\( T_0 \\) if the
 first applicable condition holds:
 
 1. \\( T_1 \\) is a cert threshold and \\( T_0 \\) is not;
-1. neither is a cert threshold and \\( T_1 \\) has the later period;
-1. they have the same period, \\( T_1 \\) is a next threshold, and \\( T_0 \\)
-   is a soft threshold;
-1. both are next thresholds in the same period, \\( T_1 \\) is for \\( \bot \\),
-   and \\( T_0 \\) is not.
+1. Neither is a cert threshold and \\( T_1 \\) has the later period;
+1. They have the same period, \\( T_1 \\) is a next threshold, and \\( T_0 \\) is a soft threshold;
+1. Both are next thresholds in the same period, \\( T_1 \\) is for \\( \bot \\), and \\( T_0 \\) is not.
 
 The numeric next-step index does not otherwise affect freshness. A threshold
 for a future round is considered when that round begins. The summary \\( C \\)

--- a/src/abft/abft-player-state.md
+++ b/src/abft/abft-player-state.md
@@ -33,7 +33,8 @@ where
 - \\( \bar{v} \\) is the _pinned_ value,
 - \\( H \\) is the ordered history of protocol events and outputs.
 
-The definitions below are derived from \\( S \\).
+The definitions below are derived from \\( S \\); observation, threshold
+formation, and freshness comparisons are evaluated in \\( H \\) order.
 
 We say that a player has _observed_
 

--- a/src/abft/abft-player-state.md
+++ b/src/abft/abft-player-state.md
@@ -54,16 +54,16 @@ thing after receiving the event. For instance, a player may observe a
 vote \\( \Vote \\), which adds this vote to \\( V \\):
 
 $$
-N((r, p, s, \bar{s}, V, P, \bar{v}, H), L_0, \Vote)
-= ((r', p', s', \bar{s}', V \cup \\{\Vote\\}, P, \bar{v}', H'), L_1, \ldots)
+N((r, p, s, \bar{s}, V, P, \bar{v}, H), L, \Vote)
+= ((r', p', s', \bar{s}', V \cup \\{\Vote\\}, P, \bar{v}', H'), L', \ldots)
 $$
 
-We write \\( S \cup \\{\Vote\\} \\) for \\( S \\) with \\( \Vote \\) added to
-\\( V \\); thus the transition above is
+We write \\( S' \cup \\{\Vote\\} \\) for an output state whose \\( V \\)
+additionally contains \\( \Vote \\); thus the transition above is
 
 $$
-N((r, p, s, \bar{s}, V, P, \bar{v}, H), L_0, \Vote)
-= (S \cup \\{\Vote\\}, L_1, \ldots)
+N((r, p, s, \bar{s}, V, P, \bar{v}, H), L, \Vote)
+= (S' \cup \\{\Vote\\}, L', \ldots)
 $$
 
 Note that _observing_ a message is distinct from _receiving_ a

--- a/src/abft/abft-player-state.md
+++ b/src/abft/abft-player-state.md
@@ -1,13 +1,17 @@
+{{#include ../_include/tex-macros/domain-separators.md}}
+
 $$
 \newcommand \Vote {\mathrm{Vote}}
 \newcommand \Proposal {\mathrm{Proposal}}
 \newcommand \Bundle {\mathrm{Bundle}}
 \newcommand \Soft {\mathit{soft}}
 \newcommand \Cert {\mathit{cert}}
+\newcommand \Next {\mathit{next}}
 \newcommand \Priority {\mathrm{Priority}}
 \newcommand \VRF {\mathrm{VRF}}
 \newcommand \ProofToHash {\mathrm{ProofToHash}}
 \newcommand \Hash {\mathrm{Hash}}
+\newcommand \Encoding {\mathrm{Encoding}}
 $$
 
 # Player State Definition
@@ -15,7 +19,7 @@ $$
 We define the _player state_ \\( S \\) to be the following tuple:
 
 $$
-S = (r, p, s, \bar{s}, V, P, \bar{v})
+S = (r, p, s, \bar{s}, V, P, \bar{v}, H)
 $$
 
 where
@@ -24,22 +28,24 @@ where
 - \\( p \\) is the current period,
 - \\( s \\) is the current step,
 - \\( \bar{s} \\) is the _last concluding step_,
-- \\( V \\) is the set of all votes,
-- \\( P \\) is the set of all proposals, and
-- \\( \bar{v} \\) is the _pinned_ value.
+- \\( V \\) is the set of accepted votes,
+- \\( P \\) is the set of validated proposal payloads,
+- \\( \bar{v} \\) is the _pinned_ value,
+- \\( H \\) is the ordered history of protocol events and outputs.
+
+The definitions below are derived from \\( S \\).
 
 We say that a player has _observed_
 
 - \\( \Proposal(v) \\) if \\( \Proposal(v) \in P \\),
 - \\( \Vote(r, p, s, v) \\) if \\( \Vote(r, p, s, v) \in V \\),
-- \\( \Bundle(r, p, s, v) \\) if \\( \Bundle(r, p, s, v) \subset V \\),
-- That the round \\( r \\) (period \\( p = 0 \\)) has _begun_ if there exists some
-\\( p \\) such that \\( \Bundle(r-1, p, \Cert, v) \\) was also observed for some
-\\( v \\),
-- That the round \\( r \\), period \\( p > 0 \\) has _begun_ if there exists some
-\\( p \\) such that either
-  - \\( \Bundle(r, p-1, s, v) \\) was also observed for some \\( s > \Cert, v \\), or
-  - \\( \Bundle(r, p, \Soft, v) \\) was observed for some \\( v \\).
+- \\( \Bundle(r, p, s, v) \\) if \\( \Bundle(r, p, s, v) \subset V \\) and its threshold
+is fresher than every threshold previously observed for round \\( r \\),
+- That the round \\( r > 0 \\) (period \\( p = 0 \\)) has _begun_ if an entry was
+committed in round \\( r-1 \\),
+- That the round \\( r \\), period \\( p > 0 \\) has _begun_ if either
+  - \\( \Bundle(r, p-1, s, v) \\) was observed for some \\( s > \Cert, v \\), or
+  - \\( \Bundle(r, p, s, v) \\) was observed for some \\( s \in \{ \Soft, \Cert \}, v \\).
 
 An event causes a player to observe something if the player has not
 observed that thing before receiving the event and has observed that
@@ -47,15 +53,16 @@ thing after receiving the event. For instance, a player may observe a
 vote \\( \Vote \\), which adds this vote to \\( V \\):
 
 $$
-N((r, p, s, \bar{s}, V, P, \bar{v}), L_0, \Vote)
-= ((r', p', \ldots, V \cup \\{\Vote\\}, P, \bar{v}'), L_1, \ldots)
+N((r, p, s, \bar{s}, V, P, \bar{v}, H), L_0, \Vote)
+= ((r', p', s', \bar{s}', V \cup \\{\Vote\\}, P, \bar{v}', H'), L_1, \ldots)
 $$
 
-We abbreviate the transition above as
+We write \\( S \cup \\{\Vote\\} \\) for \\( S \\) with \\( \Vote \\) added to
+\\( V \\); thus the transition above is
 
 $$
-N((r, p, s, \bar{s}, V, P, \bar{v}), L_0, \Vote)
-= ((S \cup \Vote, P, \bar{v}), L_1, \ldots)
+N((r, p, s, \bar{s}, V, P, \bar{v}, H), L_0, \Vote)
+= (S \cup \\{\Vote\\}, L_1, \ldots)
 $$
 
 Note that _observing_ a message is distinct from _receiving_ a
@@ -69,7 +76,7 @@ We define two functions \\( \mu(S, r, p), \sigma(S, r, p) \\), which are
 defined as follows:
 
 The _frozen value_ \\( \mu(S, r, p) \\) is defined as the _proposal-value_ \\( v \\)
-in the proposal vote in round \\( r \\) and period \\( p \\) with the minimal credential.
+in the highest-priority accepted proposal vote in round \\( r \\) and period \\( p \\).
 
 More formally, then, let
 
@@ -79,23 +86,62 @@ $$
 
 where \\( V \\) is the set of votes in \\( S \\).
 
-Then if \\( \Vote_l(r, p, 0, v_l) \\) is the vote with the smallest weight in
-\\( V_{r, p} \\), then \\( \mu(S, r, p) = v_l \\).
+Let \\( z_k \\) be the raw selection-VRF output in \\( \Vote_k \in V_{r, p, 0} \\)
+and \\( w_k \\) its weight. Its priority is
 
-If \\( V_{r, p} \\) is empty, then \\( \mu(S, r, p) = \bot \\).
+$$
+\Priority(\Vote_k) = \min_{1 \leq i \leq w_k}\Hash(\Domain{CR} || \Encoding((z_k, I_k, i))).
+$$
+
+Hash outputs are compared as unsigned big-endian integers. A proposal vote has
+higher priority when its \\( \Priority \\) value is smaller. Before the filter
+timeout, \\( \mu(S, r, p) \\) is the value of the highest-priority accepted
+proposal vote. The timeout fixes that value; later proposal votes do not change
+it.
+
+If \\( V_{r, p, 0} \\) is empty, then \\( \mu(S, r, p) = \bot \\).
 
 The _staged value_ \\( \sigma(S, r, p) \\) is defined as the sole _proposal-value_
-for which there exists a soft-bundle in round \\( r \\) and period \\( p \\).
+for which the player observed a soft or cert threshold in round \\( r \\) and period \\( p \\).
 
-More formally, suppose \\( \Bundle(r, p, Soft, v) \subset V \\). Then
+More formally, if the player observed a threshold \\( \Bundle(r, p, s, v) \\), where \\( s \in \\{\Soft, \Cert\\} \\), then
 \\( \sigma(S, r, p) = v \\).
 
-If no such soft-bundle exists, then \\( \sigma(S, r, p) = \bot \\).
+If no such threshold exists, then \\( \sigma(S, r, p) = \bot \\).
 
 If there exists a proposal-value \\( v \\) such that \\( \Proposal(v) \in P \\) and
 \\( \sigma(S, r, p) = v \\), we say that \\( v \\) is _committable for round \\( r \\),
 period_ \\( p \\) (or simply that \\( v \\) is _committable_ if \\( (r, p) \\) is
 unambiguous).
+
+The _relevant value_ is
+
+$$
+\rho(S, r, p) =
+\begin{cases}
+\sigma(S, r, p) & \text{if } \sigma(S, r, p) \neq \bot, \\\\
+\mu(S, r, p) & \text{otherwise}.
+\end{cases}
+$$
+
+For each \\( (r, p) \\), let \\( C(S, r, p) = (b, v) \\) summarize the
+thresholds with step at least \\( \Next_0 \\) formed in \\( H \\): \\( b = 1 \\)
+if any has proposal value \\( \bot \\), and \\( v \\) is the proposal value of
+the latest non-bottom threshold, or \\( \bot \\) if none exists.
+
+For thresholds in one round, \\( T_1 \\) is _fresher_ than \\( T_0 \\) if the
+first applicable condition holds:
+
+1. \\( T_1 \\) is a cert threshold and \\( T_0 \\) is not;
+1. neither is a cert threshold and \\( T_1 \\) has the later period;
+1. they have the same period, \\( T_1 \\) is a next threshold, and \\( T_0 \\)
+   is a soft threshold;
+1. both are next thresholds in the same period, \\( T_1 \\) is for \\( \bot \\),
+   and \\( T_0 \\) is not.
+
+The numeric next-step index does not otherwise affect freshness. A threshold
+for a future round is considered when that round begins. The summary \\( C \\)
+includes thresholds that are not fresh enough to be observed.
 
 > [!IMPORTANT]
 > **IMPLEMENTATION:**

--- a/src/abft/abft-player-state.md
+++ b/src/abft/abft-player-state.md
@@ -127,7 +127,7 @@ $$
 For each \\( (r, p) \\), let \\( C(S, r, p) = (b, v) \\) summarize the
 thresholds with step at least \\( \Next_0 \\) formed in \\( H \\): \\( b = 1 \\)
 if any has proposal value \\( \bot \\), and \\( v \\) is the proposal value of
-the latest non-bottom threshold, or \\( \bot \\) if none exists.
+the latest threshold for a value \\( \neq \bot \\), or \\( \bot \\) if none exists.
 
 For thresholds in one round, \\( T_1 \\) is _fresher_ than \\( T_0 \\) if the
 first applicable condition holds:

--- a/src/abft/abft-player-state.md
+++ b/src/abft/abft-player-state.md
@@ -59,7 +59,8 @@ N((r, p, s, \bar{s}, V, P, \bar{v}, H), L, \Vote)
 $$
 
 We write \\( S' \cup \\{\Vote\\} \\) for an output state whose \\( V \\)
-additionally contains \\( \Vote \\); thus the transition above is
+additionally contains \\( \Vote \\), and \\( S' \cup \\{\Proposal(v)\\} \\)
+likewise for \\( P \\); thus the transition above is
 
 $$
 N((r, p, s, \bar{s}, V, P, \bar{v}, H), L, \Vote)

--- a/src/abft/abft-player-state.md
+++ b/src/abft/abft-player-state.md
@@ -94,10 +94,10 @@ $$
 $$
 
 Hash outputs are compared as unsigned big-endian integers. A proposal vote has
-higher priority when its \\( \Priority \\) value is smaller. Before the filter
-timeout, \\( \mu(S, r, p) \\) is the value of the highest-priority accepted
-proposal vote. The timeout fixes that value; later proposal votes do not change
-it.
+higher priority when its \\( \Priority \\) value is smaller.
+\\( \mu(S, r, p) \\) is the value of the highest-priority accepted proposal vote.
+It is fixed as soon as a value is staged for \\( (r, p) \\) or the player processes
+the filter timeout of period \\( p \\), whichever occurs first; later proposal votes do not change it.
 
 If \\( V_{r, p, 0} \\) is empty, then \\( \mu(S, r, p) = \bot \\).
 

--- a/src/abft/abft-relay-rules.md
+++ b/src/abft/abft-relay-rules.md
@@ -154,7 +154,7 @@ while if a player relays a valid proposal, then
 
 $$
 N(S, L, \Proposal(v))
-= (S' \cup \Proposal(v), L', (\Proposal^\ast(v), \ldots)).
+= (S' \cup \\{\Proposal(v)\\}, L', (\Proposal^\ast(v), \ldots)).
 $$
 
 If a relayed proposal is invalid, it is not observed:

--- a/src/abft/abft-relay-rules.md
+++ b/src/abft/abft-relay-rules.md
@@ -19,7 +19,7 @@ the player's observation of that message; see the [broadcast rules](./abft-broad
 below).
 
 A player may receive messages from a misbehaving peer. These cases are marked with
-an asterisk (*) and enable the node to perform a special action (e.g., disconnect
+a dagger (†) and enable the node to perform a special action (e.g., disconnect
 from the peer).
 
 > [!NOTE]
@@ -33,7 +33,7 @@ receiving that message.
 
 On receiving a vote \\( \Vote_k(r_k, p_k, s_k, v) \\) a player
 
-- Ignores* it if \\( \Vote_k \\) is malformed or trivially invalid.
+- Ignores† it if \\( \Vote_k \\) is malformed or trivially invalid.
 
 - Ignores it if \\( \Vote_k \in V \\).
 
@@ -46,7 +46,7 @@ On receiving a vote \\( \Vote_k(r_k, p_k, s_k, v) \\) a player
   - \\( r_k \notin [r,r+1] \\) or
   - \\( r_k = r + 1 \\) and either
     - \\( p_k > 0 \\) or
-    - \\( s_k \in (\Next_0, \Late) \\) or
+    - \\( s_k \in (\Next_0, \Late) \\)
 
   - \\( r_k = r \\) and one of
     - \\( p_k \notin [p-1,p+1] \\) or
@@ -94,7 +94,7 @@ $$
 
 On receiving a bundle \\( \Bundle(r_k, p_k, s_k, v) \\) a player
 
-- Ignores* it if \\( \Bundle(r_k, p_k, s_k, v) \\) is malformed or trivially invalid.
+- Ignores† it if \\( \Bundle(r_k, p_k, s_k, v) \\) is malformed or trivially invalid.
 
 - Ignores it if
   - \\( r_k \neq r \\) or
@@ -131,7 +131,7 @@ $$
 
 On receiving a proposal \\( \Proposal(v) \\) a player
 
-- Ignores* it if it is malformed or trivially invalid.
+- Ignores† it if it is malformed or trivially invalid.
 
 - Ignores it if \\( \Proposal(v) \in P \\).
 

--- a/src/abft/abft-relay-rules.md
+++ b/src/abft/abft-relay-rules.md
@@ -3,6 +3,7 @@ $$
 \newcommand \Late {\mathit{late}}
 \newcommand \Down {\mathit{down}}
 \newcommand \Next {\mathit{next}}
+\newcommand \Cert {\mathit{cert}}
 \newcommand \Bundle {\mathrm{Bundle}}
 \newcommand \Proposal {\mathrm{Proposal}}
 $$
@@ -34,11 +35,11 @@ On receiving a vote \\( \Vote_k(r_k, p_k, s_k, v) \\) a player
 
 - Ignores* it if \\( \Vote_k \\) is malformed or trivially invalid.
 
-- Ignores it if \\( s = 0 \\) and \\( \Vote_k \in V \\).
+- Ignores it if \\( \Vote_k \in V \\).
 
-- Ignores it if \\( s = 0 \\) and \\( \Vote_k \\) is an equivocation.
+- Ignores it if \\( s_k = 0 \\) and \\( \Vote_k \\) is an equivocation.
 
-- Ignores it if \\( s > 0 \\) and \\( \Vote_k \\) is a second equivocation.
+- Ignores it if \\( s_k > 0 \\) and \\( \Vote_k \\) is a second equivocation.
 
 - Ignores it if
 
@@ -51,7 +52,8 @@ On receiving a vote \\( \Vote_k(r_k, p_k, s_k, v) \\) a player
     - \\( p_k \notin [p-1,p+1] \\) or
     - \\( p_k = p + 1 \\) and \\( s_k \in (\Next_0, \Late) \\) or
     - \\( p_k = p \\) and \\( s_k \in (\Next_0, \Late) \\) and \\( s_k \notin [s-1,s+1] \\) or
-    - \\( p_k = p - 1 \\) and \\( s_k \in (\Next_0, \Late) \\) and \\( s_k \notin [\bar{s}-1,\bar{s}+1] \\).
+    - \\( p > 0 \\) and \\( p_k = p - 1 \\) and \\( s_k \in (\Next_0, \Late) \\) and
+      \\( s_k \notin [\bar{s}-1,\bar{s}+1] \\).
 
 - Otherwise, relays \\( \Vote_k \\), observes it, and then produces any consequent
 output.
@@ -66,23 +68,22 @@ while if a player relays the vote, then
 
 $$
 N(S, L, \Vote_k(r_k, p_k, s_k, v))
-= (S' \cup \Vote(I, r_k, p_k, s_k, v), L', (\Vote_k^\ast(r_k, p_k, s_k, v),\ldots)).
+= (S' \cup \\{\Vote_k(r_k, p_k, s_k, v)\\}, L', (\Vote_k^\ast(r_k, p_k, s_k, v),\ldots)).
 $$
 
 ## Bundles
 
 On receiving a bundle \\( \Bundle(r_k, p_k, s_k, v) \\) a player
 
-- Ignores* it if \\( Bundle(r_k, p_k, s_k, v) \\) is malformed or trivially invalid.
+- Ignores* it if \\( \Bundle(r_k, p_k, s_k, v) \\) is malformed or trivially invalid.
 
 - Ignores it if
   - \\( r_k \neq r \\) or
-  - \\( r_k = r \\) and \\( p_k + 1 < p \\).
+  - \\( s_k \neq \Cert \\) and \\( p_k + 1 < p \\).
 
-- Otherwise, observes the votes in \\( \Bundle(r_k, p_k, s_k, v) \\) in sequence. If
-there exists a vote that causes the player to observe some bundle \\( \Bundle(r_k, p_k, s_k, v') \\)
-for some \\( s_k \\), then the player relays \\( \Bundle(r_k, p_k, s_k, v') \\), and
-then executes any consequent action; if there does not, the player ignores it.
+- Otherwise, verifies and observes the votes in \\( \Bundle(r_k, p_k, s_k, v) \\) in sequence. If
+there exists a vote that causes the player to observe some bundle \\( \Bundle(r_k, p_k, s_k, v') \\),
+then the player relays it and executes any consequent action; otherwise, the player ignores it.
 
 Specifically, if the player ignores the bundle without observing its
 votes, then
@@ -95,7 +96,7 @@ while if a player ignores the bundle but observes its votes, then
 
 $$
 N(S, L, \Bundle(r_k, p_k, s_k, v))
-= (S' \cup \Bundle(r_k, p_k, s_k, v), L, \epsilon);
+= (S', L, \epsilon);
 $$
 
 and if a player, on observing the votes in the bundle, observes a
@@ -104,23 +105,23 @@ value), then
 
 $$
 N(S, L, \Bundle(r_k, p_k, s_k, v))
-= (S' \cup \Bundle(r_k, p_k, s_k, v), L', (\Bundle^\ast(r_k, p_k, s_k, v'), \ldots)).
+= (S', L', (\Bundle^\ast(r_k, p_k, s_k, v'), \ldots)).
 $$
 
 ## Proposals
 
-On receiving a proposal \\( \Proposal(v) \\\) a player
-
-- Relays \\( \Proposal(v) \\) if \\( \sigma(S, r+1, 0) = v \\).
+On receiving a proposal \\( \Proposal(v) \\) a player
 
 - Ignores* it if it is malformed or trivially invalid.
 
 - Ignores it if \\( \Proposal(v) \in P \\).
 
-- Relays \\( \Proposal(v) \\), observes it, and then produces any consequent output,
-if \\( v \in \\{\sigma(S, r, p), \bar{v}, \mu(S, r, p)\\} \\).
+- Relays \\( \Proposal(v) \\) if \\( v = \bar{v} \\), \\( v = \rho(S, r, q) \\) for
+\\( q \in \\{p-1, p, p+1\\} \\) where defined, or \\( v = \rho(S, r+1, 0) \\).
 
 - Otherwise, ignores it.
+
+A relayed proposal is observed and produces any consequent output only if it is valid.
 
 Specifically, if the player ignores a proposal, then
 
@@ -128,38 +129,27 @@ $$
 N(S, L, \Proposal(v)) = (S, L, \epsilon)
 $$
 
-while if a player relays the proposal _after_ checking if it is valid, then
+while if a player relays a valid proposal, then
 
 $$
 N(S, L, \Proposal(v))
 = (S' \cup \Proposal(v), L', (\Proposal^\ast(v), \ldots)).
 $$
 
-However, in the first condition above, the player relays \\( \Proposal(v) \\) _without_
-checking if it is valid.
-
-Since the proposal has not been seen to be valid, the player cannot observe it yet,
-so
+If a relayed proposal is invalid, it is not observed:
 
 $$
-N(S, L, \Proposal(v)) = (S, L, (\Proposal^\ast(v))).
+N(S, L, \Proposal(v)) = (S', L, (\Proposal^\ast(v))).
 $$
 
 > [!NOTE]
-> An implementation may _buffer_ a proposal in this case. Specifically, an implementation
-> which relays a proposal without checking that it is valid, may optionally choose
-> to replay this event when it observes that a new round has begun (see [State Transition section](./abft-state-transitions.md)).
-> In this case, at the conclusion of a new round, this proposal is processed once
-> again as input.
-
-Implementations **MAY** store and relay fewer proposals than specified
-here to improve efficiency. However, implementations **MUST** relay proposals which
-match the following proposal-values (where \\( r \\) is the current round and \\( p \\)
-is the current period):
-
-- \\( \bar{v} \\),
-
-- \\( \sigma(S, r, p), \sigma(S, r, p-1) \\),
-
-- \\( \mu(S, r, p) \\) if \\( \sigma(S, r, p) \\) is not set and \\( \mu(S, r, p+1) \\)
-if \\( \sigma(S, r, p+1) \\) is not set.
+> Implementations **MAY** store and relay fewer proposals than specified
+> here to improve efficiency. However, implementations **MUST** relay proposals which
+> match the following proposal-values (where \\( r \\) is the current round and \\( p \\)
+> is the current period):
+>
+> - \\( \bar{v} \\),
+>
+> - \\( \rho(S, r, q) \\) for \\( q \in \\{p-1, p, p+1\\} \\) where defined,
+>
+> - \\( \rho(S, r+1, 0) \\).

--- a/src/abft/abft-relay-rules.md
+++ b/src/abft/abft-relay-rules.md
@@ -55,8 +55,21 @@ On receiving a vote \\( \Vote_k(r_k, p_k, s_k, v) \\) a player
     - \\( p > 0 \\) and \\( p_k = p - 1 \\) and \\( s_k \in (\Next_0, \Late) \\) and
       \\( s_k \notin [\bar{s}-1,\bar{s}+1] \\).
 
+- **MAY** ignore it if \\( s_k = 0 \\) and its credential does not have higher
+priority than that of every proposal-vote accepted or relayed for
+\\( (r_k, p_k) \\).
+
 - Otherwise, relays \\( \Vote_k \\), observes it, and then produces any consequent
 output.
+
+A player **MAY** also relay a verified proposal-vote with \\( r_k < r \\) and
+\\( p_k = s_k = 0 \\), without observing it, if its credential has higher
+priority than that of every proposal-vote accepted or relayed for \\( (r_k, 0) \\).
+
+> [!NOTE]
+> The reference implementation does so within a bounded window of past rounds,
+> supporting the adaptive filter timeout described in the
+> [non-normative section](./non-normative/abft-nn-dynamic-filter-timeout.md).
 
 Specifically, if a player ignores the vote, then
 
@@ -68,7 +81,13 @@ while if a player relays the vote, then
 
 $$
 N(S, L, \Vote_k(r_k, p_k, s_k, v))
-= (S' \cup \\{\Vote_k(r_k, p_k, s_k, v)\\}, L', (\Vote_k^\ast(r_k, p_k, s_k, v),\ldots)).
+= (S' \cup \\{\Vote_k(r_k, p_k, s_k, v)\\}, L', (\Vote_k^\ast(r_k, p_k, s_k, v),\ldots));
+$$
+
+and if a player relays the vote without observing it, then
+
+$$
+N(S, L, \Vote_k(r_k, p_k, s_k, v)) = (S, L, (\Vote_k^\ast(r_k, p_k, s_k, v))).
 $$
 
 ## Bundles
@@ -117,11 +136,14 @@ On receiving a proposal \\( \Proposal(v) \\) a player
 - Ignores it if \\( \Proposal(v) \in P \\).
 
 - Relays \\( \Proposal(v) \\) if \\( v = \bar{v} \\), \\( v = \rho(S, r, q) \\) for
-\\( q \in \\{p-1, p, p+1\\} \\) where defined, or \\( v = \rho(S, r+1, 0) \\).
+\\( q \in \\{p-1, p, p+1\\} \\) when not \\( \bot \\), or \\( v = \rho(S, r+1, 0) \\).
 
 - Otherwise, ignores it.
 
 A relayed proposal is observed and produces any consequent output only if it is valid.
+
+When relaying \\( Proposal(v) \\), the player **SHOULD** attach an accepted current-period
+proposal-vote for \\( v \\) as authenticator, when available.
 
 Specifically, if the player ignores a proposal, then
 
@@ -144,12 +166,12 @@ $$
 
 > [!NOTE]
 > Implementations **MAY** store and relay fewer proposals than specified
-> here to improve efficiency. However, implementations **MUST** relay proposals which
-> match the following proposal-values (where \\( r \\) is the current round and \\( p \\)
-> is the current period):
+> here to improve efficiency. However, implementations **MUST** relay, at least
+> once, proposals which match the following proposal-values (where \\( r \\) is
+> the current round and \\( p \\) is the current period):
 >
 > - \\( \bar{v} \\),
 >
-> - \\( \rho(S, r, q) \\) for \\( q \in \\{p-1, p, p+1\\} \\) where defined,
+> - \\( \rho(S, r, q) \\) for \\( q \in \\{p-1, p, p+1\\} \\) when not \\( \bot \\),
 >
 > - \\( \rho(S, r+1, 0) \\).

--- a/src/abft/abft-relay-rules.md
+++ b/src/abft/abft-relay-rules.md
@@ -160,7 +160,7 @@ $$
 If a relayed proposal is invalid, it is not observed:
 
 $$
-N(S, L, \Proposal(v)) = (S', L, (\Proposal^\ast(v))).
+N(S, L, \Proposal(v)) = (S, L, (\Proposal^\ast(v))).
 $$
 
 > [!NOTE]

--- a/src/abft/abft-relay-rules.md
+++ b/src/abft/abft-relay-rules.md
@@ -31,7 +31,7 @@ receiving that message.
 
 ## Votes
 
-On receiving a vote \\( \Vote_k(r_k, p_k, s_k, v) \\) a player
+On receiving a vote \\( \Vote_k = \Vote(I_k, r_k, p_k, s_k, v) \\) a player
 
 - Ignores† it if \\( \Vote_k \\) is malformed or trivially invalid.
 
@@ -74,20 +74,19 @@ priority than that of every proposal-vote accepted or relayed for \\( (r_k, 0) \
 Specifically, if a player ignores the vote, then
 
 $$
-N(S, L, \Vote_k(r_k, p_k, s_k, v)) = (S, L, \epsilon)
+N(S, L, \Vote_k) = (S, L, \epsilon)
 $$
 
 while if a player relays the vote, then
 
 $$
-N(S, L, \Vote_k(r_k, p_k, s_k, v))
-= (S' \cup \\{\Vote_k(r_k, p_k, s_k, v)\\}, L', (\Vote_k^\ast(r_k, p_k, s_k, v),\ldots));
+N(S, L, \Vote_k) = (S' \cup \\{\Vote_k\\}, L', (\Vote_k^\ast,\ldots));
 $$
 
 and if a player relays the vote without observing it, then
 
 $$
-N(S, L, \Vote_k(r_k, p_k, s_k, v)) = (S, L, (\Vote_k^\ast(r_k, p_k, s_k, v))).
+N(S, L, \Vote_k) = (S, L, (\Vote_k^\ast)).
 $$
 
 ## Bundles

--- a/src/abft/abft-relay-rules.md
+++ b/src/abft/abft-relay-rules.md
@@ -142,7 +142,7 @@ On receiving a proposal \\( \Proposal(v) \\) a player
 
 A relayed proposal is observed and produces any consequent output only if it is valid.
 
-When relaying \\( Proposal(v) \\), the player **SHOULD** attach an accepted current-period
+When relaying \\( \Proposal(v) \\), the player **SHOULD** attach an accepted current-period
 proposal-vote for \\( v \\) as authenticator, when available.
 
 Specifically, if the player ignores a proposal, then

--- a/src/abft/abft-state-machine.md
+++ b/src/abft/abft-state-machine.md
@@ -12,16 +12,21 @@ transmissions from the state machine.
 We can define the operation of the state machine as transitions
 between different states.
 
-A transition \\( N \\) maps some initial state
-\\( S_0 \\), a ledger \\( L_0 \\), and an event \\( e \\) to an output state
-\\( S_1 \\), an output ledger \\( L_1 \\), and a sequence of output network transmissions
+A transition \\( N \\) maps a state
+\\( S \\), a ledger \\( L \\), and an event \\( e \\) to an output state
+\\( S' \\), an output ledger \\( L' \\), and a sequence of output network transmissions
 \\( \mathbf{a} = (a_1, a_2, \ldots, a_n) \\).
 
 We write this as
 
 $$
-N(S_0, L_0, e) = (S_1, L_1, \mathbf{a})
+N(S, L, e) = (S', L', \mathbf{a})
 $$
+
+In transition equations, a primed symbol denotes a component's value after the
+transition; an unprimed symbol in the output asserts that the component is
+unchanged, except the history \\( H \\)
+([Player State](./abft-player-state.md)), which every transition extends.
 
 If no transmissions are output, we write that \\( \mathbf{a} = \epsilon \\).
 

--- a/src/abft/abft-state-machine.md
+++ b/src/abft/abft-state-machine.md
@@ -35,8 +35,8 @@ The state machine _receives_ two types of events as inputs.
 
 2. _timeout events_: A timeout event is received when a specific
    amount of time passes after the beginning of a period. A timeout
-   event \\( \lambda \\) seconds after a period \\( p \\) begins is denoted
-   \\( t(\lambda, p) \\).
+   event \\( T \\) seconds after a period \\( p \\) begins is denoted
+   \\( t(T, p) \\).
 
 > [!NOTE]
 > For more details on the way these events may be constructed from an implementation

--- a/src/abft/abft-state-transitions.md
+++ b/src/abft/abft-state-transitions.md
@@ -109,7 +109,7 @@ $$
 and
 
 $$
-P^\ast_{r, p} q = \\{\mathrm{Proposal}(v) \in P' \mid v \neq \bar{v}'
+P^\ast_{r, p} = \\{\mathrm{Proposal}(v) \in P' \mid v \neq \bar{v}'
 \land \nexists I, r', p', s' : \Vote(I, r', p', s', v) \in V' \setminus V^\ast_{r, p}\\}.
 $$
 

--- a/src/abft/abft-state-transitions.md
+++ b/src/abft/abft-state-transitions.md
@@ -60,21 +60,21 @@ In other words, if \\( v \neq \bot \\), then
 
 $$
 N((r, p-i, s, \bar{s}, V, P, \bar{v}, H), L, \ldots)
-= ((r, p, \Soft, s, V', P, v, H'), L', \ldots);
+= ((r, p, \Soft, s, V', P, v, H'), L, \ldots);
 $$
 
 and otherwise, if \\( \sigma(S, r, p-i) \neq \bot \\), then
 
 $$
 N((r, p-i, s, \bar{s}, V, P, \bar{v}, H), L, \ldots)
-= ((r, p, \Soft, s, V', P, \sigma(S, r, p-i), H'), L', \ldots);
+= ((r, p, \Soft, s, V', P, \sigma(S, r, p-i), H'), L, \ldots);
 $$
 
 and otherwise
 
 $$
 N((r, p-i, s, \bar{s}, V, P, \bar{v}, H), L, \ldots)
-= ((r, p, \Soft, s, V', P, \bar{v}, H'), L', \ldots);
+= ((r, p, \Soft, s, V', P, \bar{v}, H'), L, \ldots);
 $$
 
 for some \\( i > 0 \\) (where \\( S = (r, p-i, s, \bar{s}, V, P, \bar{v}, H) \\)).
@@ -101,8 +101,8 @@ where
 $$
 \begin{aligned}
 V^\ast_{r, p}
-&=    \\{\Vote(I, r', p', s', v) \in V' \mid r' < r\\} \\\\\\
-&\cup \\{\Vote(I, r', p', s', v) \in V' \mid r' = r, p' + 1 < p\\}
+&=    \\{\Vote(I_i, r_i, p_i, s_i, v_i) \in V' \mid r_i < r\\} \\\\\\
+&\cup \\{\Vote(I_i, r_i, p_i, s_i, v_i) \in V' \mid r_i = r, p_i + 1 < p\\}
 \end{aligned}
 $$
 
@@ -110,7 +110,7 @@ and
 
 $$
 P^\ast_{r, p} = \\{\mathrm{Proposal}(v) \in P' \mid v \neq \bar{v}'
-\land \nexists I, r', p', s' : \Vote(I, r', p', s', v) \in V' \setminus V^\ast_{r, p}\\}.
+\land \nexists I_i, r_i, p_i, s_i : \Vote(I_i, r_i, p_i, s_i, v) \in V' \setminus V^\ast_{r, p}\\}.
 $$
 
 ## New Step
@@ -137,10 +137,10 @@ In other words,
 $$
 \begin{aligned}
 &N((r, p, s, \bar{s}, V, P, \bar{v}, H), L, t(\FilterTimeout(p), p)) \\\\
-&\qquad = ((r, p, \Cert, \bar{s}, V, P, \bar{v}, H'), L', \ldots) \\\\[0.35em]
+&\qquad = ((r, p, \Cert, \bar{s}, V, P, \bar{v}, H'), L, \ldots) \\\\[0.35em]
 &N((r, p, s, \bar{s}, V, P, \bar{v}, H), L, t(\DeadlineTimeout(p), p)) \\\\
-&\qquad = ((r, p, \Next_0, \bar{s}, V, P, \bar{v}, H'), L', \ldots) \\\\[0.35em]
+&\qquad = ((r, p, \Next_0, \bar{s}, V, P, \bar{v}, H'), L, \ldots) \\\\[0.35em]
 &N((r, p, s, \bar{s}, V, P, \bar{v}, H), L, t(\DeadlineTimeout(p) + (2^{s_t} - 1)\lambda + u, p)) \\\\
-&\qquad = ((r, p, \Next_{s_t}, \bar{s}, V, P, \bar{v}, H'), L', \ldots).
+&\qquad = ((r, p, \Next_{s_t}, \bar{s}, V, P, \bar{v}, H'), L, \ldots).
 \end{aligned}
 $$

--- a/src/abft/abft-state-transitions.md
+++ b/src/abft/abft-state-transitions.md
@@ -10,7 +10,7 @@ $$
 
 # State Transitions
 
-After receiving message events or a time events, the player may update some components
+After receiving message events or timeout events, the player may update some components
 of its state.
 
 ## New Round
@@ -24,16 +24,18 @@ sets
 
 - \\( p := 0 \\),
 
-- \\( s := 0 \\).
+- \\( s := \Soft \\).
 
 Specifically, if a new round has begun, then
 
 $$
-N((r-i, p, s, \bar{s}, V, P, \bar{v}), L, \ldots)
-= ((r, 0, 0, s, V', P', \bot), L', \ldots)
+N((r-i, p, s, \bar{s}, V, P, \bar{v}, H), L, \ldots)
+= ((r, 0, \Soft, s, V', P', \bot, H'), L', \ldots)
 $$
 
 for some \\( i > 0 \\).
+
+Initially, the player starts round \\( |L|+1 \\) in \\( p = 0 \\) and \\( s = \Soft \\).
 
 > [!IMPORTANT]
 > **IMPLEMENTATION:**
@@ -42,42 +44,40 @@ for some \\( i > 0 \\).
 
 ## New Period
 
-When a player observes that a new period \\( (r, p) \\) has begun, the player sets
+When a player observes that a new period \\( (r, p) \\) has begun due to a threshold
+\\( \Bundle(r, q, s_q, v) \\), the player sets
 
 - \\( \bar{s} := s \\),
 
-- \\( s := 0 \\).
+- \\( s := \Soft \\).
 
-Also, the player sets \\( \bar{v} := v \\) if the player has observed \\( \Bundle(r, p-1, s, v) \\)
-given some values \\( s > \Cert \\) (or \\( s = \Soft \\)), \\( v \neq \bot \\);
-if none exist, the player sets \\( \bar{v} := \sigma(S, r, p-i) \\) if it exists,
-where \\( p-i \\) was the player's period immediately before observing the new period;
-and if none exist, the player does not update \\( \bar{v} \\).
+Also, the player sets \\( \bar{v} := v \\) if \\( v \neq \bot \\); otherwise,
+the player sets \\( \bar{v} := \sigma(S, r, p-i) \\) if \\( \sigma(S, r, p-i) \neq \bot \\),
+where \\( p-i \\) was the player's period immediately before observing the new period
+and otherwise, the player does not update \\( \bar{v} \\).
 
-In other words, if \\( \Bundle(r, p-1, s, v) \in V' \\) for some \\( v \neq \bot, s > \Cert \\)
-or \\( s = \Soft \\), then
+In other words, if \\( v \neq \bot \\), then
 
 $$
-N((r, p-i, s, \bar{s}, V, P, \bar{v}), L, \ldots)
-= ((r, p, 0, s, V', P, v), L', \ldots);
+N((r, p-i, s, \bar{s}, V, P, \bar{v}, H), L, \ldots)
+= ((r, p, \Soft, s, V', P, v, H'), L', \ldots);
 $$
 
-and otherwise, if \\( \Bundle(r, p-1, s, \bot) \in V' \\) for some \\( s > \Cert \\)
-with \\( \sigma(S, r, p-i) \\) defined, then
+and otherwise, if \\( \sigma(S, r, p-i) \neq \bot \\), then
 
 $$
-N((r, p-i, s, \bar{s}, V, P, \bar{v}), L, \ldots)
-= ((r, p, 0, s, V', P, \sigma(S, r, p-i)), L', \ldots);
+N((r, p-i, s, \bar{s}, V, P, \bar{v}, H), L, \ldots)
+= ((r, p, \Soft, s, V', P, \sigma(S, r, p-i), H'), L', \ldots);
 $$
 
 and otherwise
 
 $$
-N((r, p-i, s, \bar{s}, V, P, \bar{v}), L, \ldots)
-= ((r, p, 0, s, V', P, \bar{v}), L', \ldots);
+N((r, p-i, s, \bar{s}, V, P, \bar{v}, H), L, \ldots)
+= ((r, p, \Soft, s, V', P, \bar{v}, H'), L', \ldots);
 $$
 
-for some \\( i > 0 \\) (where \\( S = (r, p-i, s, \bar{s}, V, P, \bar{v}) \\)).
+for some \\( i > 0 \\) (where \\( S = (r, p-i, s, \bar{s}, V, P, \bar{v}, H) \\)).
 
 > [!IMPORTANT]
 > **IMPLEMENTATION:**
@@ -87,13 +87,13 @@ for some \\( i > 0 \\) (where \\( S = (r, p-i, s, \bar{s}, V, P, \bar{v}) \\)).
 ## Garbage Collection
 
 When a player observes that either a new _round_ or a new _period_
-\\( (r, p) \\) has begun, then the player _garbage-collects_ old state.
+\\( (r, p) \\) has begun, then the player _garbage-collects_ old votes and proposal payloads.
 
 In other words,
 
 $$
-N((r-i, p-i, s, \bar{s}, V, P, \bar{v}), L, \ldots)
-= ((r, p, \bar{s}, 0, V' \setminus V^\ast_{r, p}, P' \setminus P^\ast_{r, p}, \bar{v}), L, \ldots)
+N((r_0, p_0, s, \bar{s}, V, P, \bar{v}, H), L, \ldots)
+= ((r, p, \Soft, s, V' \setminus V^\ast_{r, p}, P' \setminus P^\ast_{r, p}, \bar{v}', H'), L', \ldots)
 $$
 
 where
@@ -101,26 +101,31 @@ where
 $$
 \begin{aligned}
 V^\ast_{r, p}
-&=    \\{\Vote(I, r', p', \bar{s}, v) | \Vote \in V, r' < r\\} \\\\\\
-&\cup \\{\Vote(I, r', p', \bar{s}, v) | \Vote \in V, r' = r, p' + 1 < p\\}
+&=    \\{\Vote(I, r', p', s', v) \in V' \mid r' < r\\} \\\\\\
+&\cup \\{\Vote(I, r', p', s', v) \in V' \mid r' = r, p' + 1 < p\\}
 \end{aligned}
 $$
 
-and \\( P^\ast_{r, p} \\) is defined similarly.
+and
+
+$$
+P^\ast_{r, p} q = \\{\mathrm{Proposal}(v) \in P' \mid v \neq \bar{v}'
+\land \nexists I, r', p', s' : \Vote(I, r', p', s', v) \in V' \setminus V^\ast_{r, p}\\}.
+$$
 
 ## New Step
 
 A player may also update its step after receiving a timeout event.
 
-On observing a timeout event of \\( \FilterTimeout(p) \\) for a period \\( p \\),
-the player sets \\( s := \Cert \\).
+On observing a timeout event of \\( \FilterTimeout(p) \\) for its current period \\( p \\),
+the player freezes \\( \mu(S, r, p) \\) and sets \\( s := \Cert \\).
 
-On observing a timeout event of \\( \DeadlineTimeout(p) \\) for a period \\( p \\),
+On observing a timeout event of \\( \DeadlineTimeout(p) \\) for its current period \\( p \\),
 the player sets \\( s := \Next_0 \\).
 
-On observing a timeout event of \\( \DeadlineTimeout(p) + 2^{s_t}\lambda + u \\)
-where \\( u \in [0, 2^{s_t}\lambda) \\) sampled uniformly at random, the player sets
-\\( s := s_t \\).
+For \\( 1 \leq s_t \leq 249 \\), on observing a timeout event of \\( \DeadlineTimeout(p) + (2^{s_t} - 1)\lambda + u \\)
+for its current period, where \\( u \in [0, 2^{s_t}\lambda) \\) is sampled uniformly at random, the player sets
+\\( s := \Next_{s_t} \\).
 
 > [!IMPORTANT]
 > **IMPLEMENTATION:**
@@ -131,11 +136,11 @@ In other words,
 
 $$
 \begin{aligned}
-&N((r, p, s, \bar{s}, V, P, \bar{v}), L, t(\FilterTimeout(p), p)) \\\\
-&\qquad = ((r, p, \Cert, \bar{s}, V, P, \bar{v}), L', \ldots) \\\\[0.35em]
-&N((r, p, s, \bar{s}, V, P, \bar{v}), L, t(\DeadlineTimeout(p), p)) \\\\
-&\qquad = ((r, p, \Next_0, \bar{s}, V, P, \bar{v}), L', \ldots) \\\\[0.35em]
-&N((r, p, s, \bar{s}, V, P, \bar{v}), L, t(\DeadlineTimeout(p) + 2^{s_t}\lambda + u, p)) \\\\
-&\qquad = ((r, p, \Next_{s_t}, \bar{s}, V, P, \bar{v}), L', \ldots).
+&N((r, p, s, \bar{s}, V, P, \bar{v}, H), L, t(\FilterTimeout(p), p)) \\\\
+&\qquad = ((r, p, \Cert, \bar{s}, V, P, \bar{v}, H'), L', \ldots) \\\\[0.35em]
+&N((r, p, s, \bar{s}, V, P, \bar{v}, H), L, t(\DeadlineTimeout(p), p)) \\\\
+&\qquad = ((r, p, \Next_0, \bar{s}, V, P, \bar{v}, H'), L', \ldots) \\\\[0.35em]
+&N((r, p, s, \bar{s}, V, P, \bar{v}, H), L, t(\DeadlineTimeout(p) + (2^{s_t} - 1)\lambda + u, p)) \\\\
+&\qquad = ((r, p, \Next_{s_t}, \bar{s}, V, P, \bar{v}, H'), L', \ldots).
 \end{aligned}
 $$


### PR DESCRIPTION
## Summary

This PR consolidates the changes proposed in: #199, #200, #202, #206, and #210.

It corrects the normative ABFT section based on some changes proposed in those PRs and some new findings; all have been AI-reviewd against the reference implementation (`go-algorand` `88fe542f`, which is assumed correct) and kept or discarded accordingly.

The changes introduce a the following new concepts:

- **History `H`**: the player state gains an ordered history of events and outputs.
- **Threshold freshness**: a per-round ordering (cert, then later period, next over soft, bottom over value); a bundle is *observed* only if fresher than every threshold observed before it. Replaces the set-membership model, which could not express that a verified but non-fresher quorum is neither relayed nor staged.
- **Summary `C(S, r, p)`**: whether a bottom next threshold formed, and the latest non-bottom value; filtering, recovery, and fast recovery select their carried value from it, correcting the previous use of the pinned value `v̄` (now used for payload relay only).

Garbage collection section is deliberately kept, corrected in place. AI-review suggested a full removal: it defines no externally visible behavior, and the reference implementation itself retains more than the transition mandates.

Suggested file review order:

1. `abft-notation.md`;
2. `abft-parameters`;
3. `abft-participants.md`;
4. `abft-ledger.md`;
5. `abft-messages.md`;
6. `abft-state-machine.md;`
7. `abft-player-state.md`;
8. `abft-relay-rules.md`;
9. `abft-state-transitions.md`;
10. `abft-broadcast-rules.md`.

## Validation

- [x] I ran `make ci`, or `make check` with no version-drift warnings.
- [x] I checked the deployment preview when the change affects rendering.
