### PR TITLE
Fix broken json_ref RFC link

### DIFF
--- a/src/_include/auto/opcodes/byte-array-manipulation.md
+++ b/src/_include/auto/opcodes/byte-array-manipulation.md
@@ -16,4 +16,4 @@
 | `replace2 s` | Copy of A with the bytes starting at S replaced by the bytes of B. Fails if S+len(B) exceeds len(A) |
 | `replace3` | Copy of A with the bytes starting at B replaced by the bytes of C. Fails if B+len(C) exceeds len(A) |
 | `base64_decode e` | decode A which was base64-encoded using _encoding_ E. Fail if A is not base64 encoded with encoding E |
-| `json_ref r` | key B's value, of type R, from a [valid](jsonspec.md) utf-8 encoded json object A |
+| `json_ref r` | key B's value, of type R, from a [valid](https://datatracker.ietf.org/doc/html/rfc8259) utf-8 encoded json object A |

--- a/src/avm/avm-appendix-a.md
+++ b/src/avm/avm-appendix-a.md
@@ -859,7 +859,7 @@ _Warning_: Usage should be restricted to very rare use cases. In almost all case
 - Syntax: `json_ref R` where R: [json_ref Types](#json_ref-types)
 - Bytecode: 0x5f {uint8}
 - Stack: ..., A: []byte, B: []byte &rarr; ..., any
-- key B's value, of type R, from a [valid](jsonspec.md) utf-8 encoded json object A
+- key B's value, of type R, from a [valid](https://datatracker.ietf.org/doc/html/rfc8259) utf-8 encoded json object A
 - **Cost**: 25 + 2 per 7 bytes of A
 - Availability: v7
 


### PR DESCRIPTION
## Summary

- Replace the broken relative `jsonspec.md` link in the `json_ref` opcode documentation with the canonical RFC 8259 URL.
- Update both checked-in generated views: the AVM appendix and the byte-array-manipulation opcode group.

Closes #297.

## Verification

- Confirmed `https://datatracker.ietf.org/doc/html/rfc8259` returns HTTP 200.
- `git diff --check`
- Pinned Docker lint suite: passed (`rumdl`, local-link checks, and standard hooks).
- Pinned Docker `mdbook test .`: passed.
- Pinned Docker HTML build: passed.
- Pinned Docker rendered-HTML link check: passed.